### PR TITLE
Typo Bug in ili9163c_fill_screen

### DIFF
--- a/opendps/ili9163c.c
+++ b/opendps/ili9163c.c
@@ -230,7 +230,7 @@ void ili9163c_fill_screen(uint16_t color)
 {
     uint32_t i;
     uint8_t hi = color >> 8;
-    uint8_t lo = color && 0xff;
+    uint8_t lo = color & 0xff; 
     uint8_t fill[] = {hi, lo, hi, lo, hi, lo, hi, lo, hi, lo, hi, lo, hi, lo, hi, lo};
     uint8_t dummy[sizeof(fill)];
     gpio_clear(TFT_A0_PORT, TFT_A0_PIN);


### PR DESCRIPTION
Typo Bug in ili9163c_fill_screen using Logical and (&&) but should be bitwise and (&)