### PR TITLE
Fix build break on debian linux, point OPENCM3_DIR to local directory if not set

### DIFF
--- a/libopencm3.target.mk
+++ b/libopencm3.target.mk
@@ -42,6 +42,10 @@ BMP_PORT	?=
 #STLINK_PORT	?= :4242
 
 # DPS5005
+ifeq ($(strip $(OPENCM3_DIR)),)
+OPENCM3_DIR = ../libopencm3
+endif
+
 LDSCRIPT = $(OPENCM3_DIR)/lib/stm32/f1/stm32f100x8.ld
 
 # Blue pill


### PR DESCRIPTION

Wasn't able to compile given your instructions at https://johan.kanflo.com/upgrading-your-dps5005/. I had to set the OPENCM3_DIR on my debian based box.