### PR TITLE
Support for DPS5015 and CC+CV mode (CurrentLimit)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ protocol_test
 build/
 firmware/
 html/
+*~

--- a/opendps/cli.c
+++ b/opendps/cli.c
@@ -83,9 +83,9 @@ void cli_run(const cli_command_t cmds[], const uint32_t num, char *line)
     for (uint32_t i=0; i<num; i++) {
         if (cmds[i].cmd && strcmp(argv[0], cmds[i].cmd) == 0) {
             if (cmds[i].min_arg > argc-1 || cmds[i].max_arg < argc-1) {
-                printf("Wrong number of arguments:\n");
+                printf("Wrong number of arguments:\r\n");
                 if (cmds[i].usage) {
-                    printf("Usage: %s%s%s;\n", cmds[i].cmd, ARG_DELIMITER_STR, cmds[i].usage);
+                    printf("Usage: %s%s%s;\r\n", cmds[i].cmd, ARG_DELIMITER_STR, cmds[i].usage);
                 }
             } else {
                 cmds[i].handler(argc, argv);
@@ -105,12 +105,12 @@ void cli_run(const cli_command_t cmds[], const uint32_t num, char *line)
             }
             for (uint32_t i=0; i<num; i++) {
                 if (cmds[i].help) {
-                    printf("%-*s %s\n", (int) max_len+CMD_EXTRA_PADDING, cmds[i].cmd, cmds[i].help);
+                    printf("%-*s %s\r\n", (int) max_len+CMD_EXTRA_PADDING, cmds[i].cmd, cmds[i].help);
                 }
             }
-            printf("(end commands with semicolon, not enter).\n");
+            printf("(end commands with semicolon, not enter).\r\n");
         } else {
-            printf("Unknown command, try 'help'\n");
+            printf("Unknown command, try 'help'\r\n");
         }
     }
 }

--- a/opendps/cli.c
+++ b/opendps/cli.c
@@ -83,9 +83,9 @@ void cli_run(const cli_command_t cmds[], const uint32_t num, char *line)
     for (uint32_t i=0; i<num; i++) {
         if (cmds[i].cmd && strcmp(argv[0], cmds[i].cmd) == 0) {
             if (cmds[i].min_arg > argc-1 || cmds[i].max_arg < argc-1) {
-                printf("Wrong number of arguments:\r\n");
+                printf("Wrong number of arguments:\n");
                 if (cmds[i].usage) {
-                    printf("Usage: %s%s%s;\r\n", cmds[i].cmd, ARG_DELIMITER_STR, cmds[i].usage);
+                    printf("Usage: %s%s%s;\n", cmds[i].cmd, ARG_DELIMITER_STR, cmds[i].usage);
                 }
             } else {
                 cmds[i].handler(argc, argv);
@@ -105,12 +105,12 @@ void cli_run(const cli_command_t cmds[], const uint32_t num, char *line)
             }
             for (uint32_t i=0; i<num; i++) {
                 if (cmds[i].help) {
-                    printf("%-*s %s\r\n", (int) max_len+CMD_EXTRA_PADDING, cmds[i].cmd, cmds[i].help);
+                    printf("%-*s %s\n", (int) max_len+CMD_EXTRA_PADDING, cmds[i].cmd, cmds[i].help);
                 }
             }
-            printf("(end commands with semicolon, not enter).\r\n");
+            printf("(end commands with semicolon, not enter).\n");
         } else {
-            printf("Unknown command, try 'help'\r\n");
+            printf("Unknown command, try 'help'\n");
         }
     }
 }

--- a/opendps/command_handler.c
+++ b/opendps/command_handler.c
@@ -153,7 +153,6 @@ static void off_cmd(uint32_t argc, char *argv[])
 }
 
 extern volatile uint16_t a_in_adc;
-extern volatile uint16_t v_in_adc;
 static void stat_cmd(uint32_t argc, char *argv[])
 {
     (void) argc;
@@ -177,7 +176,7 @@ static void stat_cmd(uint32_t argc, char *argv[])
     printf(" V_in  : %2lu.%02lu V\n", v_in/1000,  (v_in%1000)/10);
     printf(" set  U out : %2lu.%02lu V\n", v_set/1000, (v_set%1000)/10);
     printf(" real U out : %2lu.%02lu V (%s)\n", v_out/1000, (v_out%1000)/10, pwrctl_vout_enabled() ? "enabled" : "disabled");
-    printf(" ADC(U): %d\n",v_in_adc);
+    printf(" ADC(U): %d\n",v_out_raw);
     printf(" set  I out : %2lu.%03lu A\n", i_set/1000, i_set%1000);
     printf(" real I out : %2lu.%03lu A\n", i_out/1000, i_out%1000);
     printf(" ADC(I): %d\n",a_in_adc);

--- a/opendps/command_handler.c
+++ b/opendps/command_handler.c
@@ -143,11 +143,6 @@ static void on_cmd(uint32_t argc, char *argv[])
     printf("Power on\n");
     pwrctl_enable_vout(true);
     ui_update_power_status(true);
-
-
-#warning TEMPORARY HACK TO UNFREEZE LCD
-    ili9163c_init();
-    ili9163c_set_rotation(3); // Specific for DPS5005
 }
 
 static void off_cmd(uint32_t argc, char *argv[])

--- a/opendps/command_handler.c
+++ b/opendps/command_handler.c
@@ -141,8 +141,7 @@ static void on_cmd(uint32_t argc, char *argv[])
     (void) argc;
     (void) argv;
     printf("Power on\n");
-    pwrctl_enable_vout(true);
-    ui_update_power_status(true);
+    ui_enable_power(true);
 }
 
 static void off_cmd(uint32_t argc, char *argv[])
@@ -150,8 +149,7 @@ static void off_cmd(uint32_t argc, char *argv[])
     (void) argc;
     (void) argv;
     printf("Power off\n");
-    pwrctl_enable_vout(false);
-    ui_update_power_status(false);
+    ui_enable_power(false);
 }
 
 extern volatile uint16_t a_in_adc;

--- a/opendps/command_handler.c
+++ b/opendps/command_handler.c
@@ -121,7 +121,6 @@ void serial_handle_rx_char(char c)
     } else if (i >= sizeof(buffer) - 1) {
         usart_send_blocking(USART1, '\a');
     } else if (c == ';') {
-        usart_send_blocking(USART1, '\r');
         usart_send_blocking(USART1, '\n');
         if (strlen(buffer) > 0) {
             cli_run(commands, sizeof(commands) / sizeof(cli_command_t), (char*) buffer);
@@ -141,7 +140,7 @@ static void on_cmd(uint32_t argc, char *argv[])
 {
     (void) argc;
     (void) argv;
-    printf("Power on\r\n");
+    printf("Power on\n");
     pwrctl_enable_vout(true);
     ui_update_power_status(true);
 
@@ -155,7 +154,7 @@ static void off_cmd(uint32_t argc, char *argv[])
 {
     (void) argc;
     (void) argv;
-    printf("Power off\r\n");
+    printf("Power off\n");
     pwrctl_enable_vout(false);
     ui_update_power_status(false);
 }
@@ -175,41 +174,41 @@ static void stat_cmd(uint32_t argc, char *argv[])
     uint32_t v_set=pwrctl_get_vout();
     uint32_t i_set=pwrctl_get_iout();
     if(mode==pm_current_limit)
-        printf(" Mode  : CL\r\n");
+        printf(" Mode  : CL\n");
     else if(mode==pm_constant_current)
-        printf(" Mode  : CC\r\n");
+        printf(" Mode  : CC\n");
     else if(mode==pm_constant_voltage)
-        printf(" Mode  : CV\r\n");
+        printf(" Mode  : CV\n");
     else
-        printf(" Mode  : %d\r\n",mode);
-    printf(" V_in  : %2lu.%02lu V\r\n", v_in/1000,  (v_in%1000)/10);
-    printf(" set  U out : %2lu.%02lu V\r\n", v_set/1000, (v_set%1000)/10);
-    printf(" real U out : %2lu.%02lu V (%s)\r\n", v_out/1000, (v_out%1000)/10, pwrctl_vout_enabled() ? "enabled" : "disabled");
-    printf(" ADC(U): %d\r\n",v_in_adc);
-    printf(" set  I out : %2lu.%03lu A\r\n", i_set/1000, i_set%1000);
-    printf(" real I out : %2lu.%03lu A\r\n", i_out/1000, i_out%1000);
-    printf(" ADC(I): %d\r\n",a_in_adc);
+        printf(" Mode  : %d\n",mode);
+    printf(" V_in  : %2lu.%02lu V\n", v_in/1000,  (v_in%1000)/10);
+    printf(" set  U out : %2lu.%02lu V\n", v_set/1000, (v_set%1000)/10);
+    printf(" real U out : %2lu.%02lu V (%s)\n", v_out/1000, (v_out%1000)/10, pwrctl_vout_enabled() ? "enabled" : "disabled");
+    printf(" ADC(U): %d\n",v_in_adc);
+    printf(" set  I out : %2lu.%03lu A\n", i_set/1000, i_set%1000);
+    printf(" real I out : %2lu.%03lu A\n", i_out/1000, i_out%1000);
+    printf(" ADC(I): %d\n",a_in_adc);
     int acc=0;
     if(mode==pm_constant_current){
         acc=1;
     }else if(pwrctl_vout_enabled()){
         if(v_set>v_out) acc=1;
     }
-    printf("Actual mode: %s\r\n",acc?"CC":"CV");
+    printf("Actual mode: %s\n",acc?"CC":"CV");
 }
 
 static void u_cmd(uint32_t argc, char *argv[])
 {
     (void) argc;
     uint32_t v_out = atoi(argv[1]);
-    printf("Setting U(out) to %lumv\r\n", v_out);
+    printf("Setting U(out) to %lumv\n", v_out);
     ui_set_voltage(v_out);
 }
 static void i_cmd(uint32_t argc, char *argv[])
 {
     (void) argc;
     uint32_t a_out = atoi(argv[1]);
-    printf("Setting A(out) to %luma\r\n", a_out);
+    printf("Setting A(out) to %luma\n", a_out);
     ui_set_current(a_out);
 }
 static void cv_cmd(uint32_t argc, char *argv[])
@@ -217,20 +216,20 @@ static void cv_cmd(uint32_t argc, char *argv[])
     (void) argc;
     (void) argv;
     int success = ui_set_power_mode(pm_constant_voltage);
-    printf("Setting CV mode %d\r\n", success);
+    printf("Setting CV mode %d\n", success);
 }
 static void cc_cmd(uint32_t argc, char *argv[])
 {
     (void) argc;
     (void) argv;
     int success = ui_set_power_mode(pm_constant_current);
-    printf("Setting CC mode %d\r\n", success);
+    printf("Setting CC mode %d\n", success);
 }
 static void cl_cmd(uint32_t argc, char *argv[])
 {
     (void) argc;
     (void) argv;
     int success = ui_set_power_mode(pm_current_limit);
-    printf("Setting CL mode %d\r\n", success);
+    printf("Setting CL mode %d\n", success);
 }
 

--- a/opendps/dps-model.h
+++ b/opendps/dps-model.h
@@ -7,33 +7,72 @@
 /*
  * K - angle factor
  * C - offset
+ * for ADC
  * K = (I1-I2)/(ADC1-ADC2)
  * C = I1-K*ADC1
+ * for DAC
+ * K = (DAC1-DAC2)/(I1-I2)
+ * C = DAC1-K*I1
  */
+
+/* Exmaple for voltage ADC calibration
+ * you can see real ADC value in CLI mode's stat:
+ *                         ADC(U): 394
+ * and you have to measure real voltage with reference voltmeter.
+ * ADC value -> Voltage calculation
+ * ADC  394 =  5001 mV
+ * ADC  782 = 10030 mV
+ * ADC 1393 = 18000 mV
+ * K = (U1-U2)/(ADC1-ADC2) = (18000-5001)/(1393-394) = 76.8461538
+ * C = U1-K*ADC1= 5001-K*394  = -125.732
+ *
+ * */
+
+/* Example for voltage DAC calibration 
+ * DAC value -> Voltage
+ * You can write DAC values to DHR12R1 register 0x40007408
+ * over openocd console:
+ * mww 0x40007408 77
+ * and measure real voltage with reference voltmeter.
+ *
+ * DAC   77 =  1004 mV
+ *      872 = 12005 mV
+ *  K = (DAC1-DAC2)/(U1-U2) = (77-872)/(1004-12005) = .072266
+ *  C = DAC1-K*U1 = 77-(K*1004) = 4.44477774
+ *
+ * */
+
 
 #ifdef DPS5015 
 // DPS5015
 
 #define ADC_CHA_IOUT_GOLDEN_VALUE  (59)
-#define CUR_ADC_K (double)6.8403
-//#define CUR_ADC_C (double)-460.00
-#define CUR_ADC_C (double)-394.06
-/*
-#define CUR_ADC_K (double)6.7770
-#define CUR_ADC_C (double)-394.06
-*/
+#define A_ADC_K (double)6.8403
+#define A_ADC_C (double)-394.06
+#define A_DAC_K (double)0.166666
+#define A_DAC_C (double)261.6666
 
-#define CUR_DAC_K (double)0.166666
-#define CUR_DAC_C (double)261.6666
+
+#define V_ADC_K (double)13.012
+#define V_ADC_C (double)-125.732
+
+
+#define V_DAC_K (double)0.072266
+#define V_DAC_C (double)4.444777
 
 #else
 // DPS5005
 
 #define ADC_CHA_IOUT_GOLDEN_VALUE  (0x45)
-#define CUR_ADC_K (double)1.713
-#define CUR_ADC_C (double)-118.51
-#define CUR_DAC_K (double)0.652
-#define CUR_DAC_C (double)288.611
+#define A_ADC_K (double)1.713
+#define A_ADC_C (double)-118.51
+#define A_DAC_K (double)0.652
+#define A_DAC_C (double)288.611
+
+#define V_DAC_K (double)0.072
+#define V_DAC-C (double)1.85
+#define V_ADC_K (double)13.164
+#define V_ADC_C (double)-100.751
 
 #endif
 

--- a/opendps/dps-model.h
+++ b/opendps/dps-model.h
@@ -3,7 +3,41 @@
 
 // if no other DPSxxxx model is specified, we will assume DPS5005
 
-// #define DPS5015 
+#define DPS5015 
+
+/*
+ * K - angle factor
+ * C - offset
+ * K = (I1-I2)/(ADC1-ADC2)
+ * C = I1-K*ADC1
+ */
+
+#ifdef DPS5015 
+// DPS5015
+
+#define ADC_CHA_IOUT_GOLDEN_VALUE  (59)
+#define CUR_ADC_K (double)6.8403
+//#define CUR_ADC_C (double)-460.00
+#define CUR_ADC_C (double)-394.06
+/*
+#define CUR_ADC_K (double)6.7770
+#define CUR_ADC_C (double)-394.06
+*/
+
+#define CUR_DAC_K (double)0.166666
+#define CUR_DAC_C (double)261.6666
+
+#else
+// DPS5005
+
+#define ADC_CHA_IOUT_GOLDEN_VALUE  (0x45)
+#define CUR_ADC_K (double)1.713
+#define CUR_ADC_C (double)-118.51
+#define CUR_DAC_K (double)0.652
+#define CUR_DAC_C (double)288.611
+
+#endif
+
 
 
 #endif // __DPS_MODEL_H__

--- a/opendps/dps-model.h
+++ b/opendps/dps-model.h
@@ -2,8 +2,7 @@
 #define __DPS_MODEL_H__
 
 // if no other DPSxxxx model is specified, we will assume DPS5005
-
-#define DPS5015 
+//#define DPS5015 
 
 /*
  * K - angle factor

--- a/opendps/graphics.h
+++ b/opendps/graphics.h
@@ -2,6 +2,7 @@
 #define __GRAPHICS_H__
 #include "cc.h"
 #include "cv.h"
+#include "cl.h"
 #include "logo.h"
 #include "padlock.h"
 #include "power.h"

--- a/opendps/hw.c
+++ b/opendps/hw.c
@@ -397,8 +397,13 @@ static void gpio_init(void)
     // PA7  I 0 An                    ADC1_IN7        R30-U2.7:V_OUT-B
 //tft    gpio_set_mode(GPIOA, GPIO_MODE_INPUT, GPIO_CNF_INPUT_ANALOG, GPIO7);
 
+#ifdef TFT_CSN_PORT
+    gpio_set_mode(TFT_CSN_PORT, GPIO_MODE_OUTPUT_50_MHZ, GPIO_CNF_OUTPUT_PUSHPULL, TFT_CSN_PIN);
+    gpio_set(TFT_CSN_PORT, TFT_CSN_PIN);
+#else
     // PA8  O 0 PP     (50 Mhz)       TFT.7           (not used by TFT)
     gpio_set_mode(GPIOA, GPIO_MODE_OUTPUT_50_MHZ, GPIO_CNF_OUTPUT_PUSHPULL, GPIO8);
+#endif
 
     // PA9  I 1 Flt
 //    gpio_set_mode(GPIOA, GPIO_MODE_INPUT, GPIO_CNF_INPUT_FLOAT, GPIO9);

--- a/opendps/hw.c
+++ b/opendps/hw.c
@@ -244,7 +244,8 @@ void adc1_2_isr(void)
         }
     }
     if (pwrctl_i_limit_raw) {
-        if (adc_counter >= STARTUP_SKIP_COUNT) {
+        //skip STARTUP_SKIP_COUNT counts and 2 mSec
+        if (adc_counter >= STARTUP_SKIP_COUNT && get_ticks()-pwr_start>2) {
             i += adc_i_offset;
             if (i > pwrctl_i_limit_raw) { /** OCP! */
                 handle_ocp(i);

--- a/opendps/hw.h
+++ b/opendps/hw.h
@@ -24,6 +24,7 @@
 
 #ifndef __HW_H__
 #define __HW_H__
+#include "dps-model.h"
 
 /** We can provide max 800mV below Vin */
 #define V_IO_DELTA (800)
@@ -36,6 +37,10 @@
 #define TFT_RST_PIN  GPIO12
 #define TFT_A0_PORT  GPIOB
 #define TFT_A0_PIN   GPIO14
+#ifdef DPS5015 
+#define TFT_CSN_PORT GPIOA
+#define TFT_CSN_PIN  GPIO8
+#endif
 
 #define BUTTON_SEL_PORT GPIOA
 #define BUTTON_SEL_PIN  GPIO2

--- a/opendps/opendps.c
+++ b/opendps/opendps.c
@@ -107,8 +107,8 @@ int main(void)
     event_init();
 
 #ifdef CONFIG_COMMANDLINE
-    printf("Welcome to OpenDPS!\n");
-    printf("Try 'help;' for, well, help (note the semicolon).\n");
+    printf("\r\nWelcome to OpenDPS!\r\n");
+    printf("Try 'help;' for, well, help (note the semicolon).\r\n");
 #endif // CONFIG_COMMANDLINE
 
     tft_init();

--- a/opendps/opendps.c
+++ b/opendps/opendps.c
@@ -107,8 +107,8 @@ int main(void)
     event_init();
 
 #ifdef CONFIG_COMMANDLINE
-    printf("\r\nWelcome to OpenDPS!\r\n");
-    printf("Try 'help;' for, well, help (note the semicolon).\r\n");
+    printf("\nWelcome to OpenDPS!\n");
+    printf("Try 'help;' for, well, help (note the semicolon).\n");
 #endif // CONFIG_COMMANDLINE
 
     tft_init();

--- a/opendps/pwrctl.c
+++ b/opendps/pwrctl.c
@@ -176,7 +176,7 @@ uint32_t pwrctl_calc_vin(uint16_t raw)
   */
 uint32_t pwrctl_calc_vout(uint16_t raw)
 {
-    return 13.164*raw - 100.751;
+    return V_ADC_K*raw + V_ADC_C;
 }
 
 /**
@@ -186,7 +186,7 @@ uint32_t pwrctl_calc_vout(uint16_t raw)
   */
 uint16_t pwrctl_calc_vout_dac(uint32_t v_out_mv)
 {
-    uint32_t dac = 0.072*v_out_mv + 1.85;
+    uint32_t dac = V_DAC_K*v_out_mv + V_DAC_C;
     return dac & 0xfff; /** 12 bits */
 }
 
@@ -197,7 +197,7 @@ uint16_t pwrctl_calc_vout_dac(uint32_t v_out_mv)
   */
 uint32_t pwrctl_calc_iout(uint16_t raw)
 {
-    return CUR_ADC_K*raw + CUR_ADC_C;
+    return A_ADC_K*raw + A_ADC_C;
 }
 
 /**
@@ -207,7 +207,7 @@ uint32_t pwrctl_calc_iout(uint16_t raw)
   */
 uint16_t pwrctl_calc_ilimit_adc(uint16_t i_limit_ma)
 {
-    return (i_limit_ma - CUR_ADC_C) / CUR_ADC_K + 1;
+    return (i_limit_ma - A_ADC_C) / A_ADC_K + 1;
 }
 
 /**
@@ -219,7 +219,7 @@ uint16_t pwrctl_calc_ilimit_adc(uint16_t i_limit_ma)
   */
 uint16_t pwrctl_calc_iout_dac(uint32_t i_out_ma)
 {
-    uint32_t dac = CUR_DAC_K * i_out_ma + CUR_DAC_C;
+    uint32_t dac = A_DAC_K * i_out_ma + A_DAC_C;
     return dac & 0xfff; /** 12 bits */
 }
 

--- a/opendps/pwrctl.c
+++ b/opendps/pwrctl.c
@@ -27,6 +27,7 @@
 #include <stdio.h>
 #include <gpio.h>
 #include <dac.h>
+#include "tick.h"
 
 /** This module handles voltege and current calculations on the DPS5005
   * Calculations based on measurements found at
@@ -38,6 +39,9 @@ static bool v_out_enabled;
 
 /** not static as it is referred to from hw.c for performance reasons */
 uint32_t pwrctl_i_limit_raw;
+
+/** Time at wich V_out was enabled */
+uint64_t pwr_start;
 
 /**
   * @brief Initialize the power control module
@@ -122,27 +126,28 @@ uint32_t pwrctl_get_ilimit(void)
   */
 void pwrctl_enable_vout(bool enable)
 {
-  v_out_enabled = enable;
-  if (v_out_enabled)
-  {
+    v_out_enabled = enable;
+    if (v_out_enabled)
+    {
+        pwr_start = get_ticks();
 #ifdef DPS5015
-    //gpio_clear(GPIOA, GPIO9); // this is power control on '5015
-    gpio_set(GPIOB, GPIO11);    // B11 is fan control on '5015
-    gpio_clear(GPIOC, GPIO13);  // C13 is power control on '5015
+        //gpio_clear(GPIOA, GPIO9); // this is power control on '5015
+        gpio_set(GPIOB, GPIO11);    // B11 is fan control on '5015
+        gpio_clear(GPIOC, GPIO13);  // C13 is power control on '5015
 #else
-    gpio_clear(GPIOB, GPIO11);  // B11 is power control on '5005
+        gpio_clear(GPIOB, GPIO11);  // B11 is power control on '5005
 #endif
-  }
-  else
-  {
+    }
+    else
+    {
 #ifdef DPS5015
-    //gpio_set(GPIOA, GPIO9);    // gpio_set(GPIOB, GPIO11);
-    gpio_clear(GPIOB, GPIO11); // B11 is fan control on '5015
-    gpio_set(GPIOC, GPIO13);   // C13 is power control on '5015
+        //gpio_set(GPIOA, GPIO9);    // gpio_set(GPIOB, GPIO11);
+        gpio_clear(GPIOB, GPIO11); // B11 is fan control on '5015
+        gpio_set(GPIOC, GPIO13);   // C13 is power control on '5015
 #else
-    gpio_set(GPIOB, GPIO11);  // B11 is power control on '5005
+        gpio_set(GPIOB, GPIO11);  // B11 is power control on '5005
 #endif
-  }
+    }
 }
 
 /**

--- a/opendps/pwrctl.h
+++ b/opendps/pwrctl.h
@@ -51,6 +51,12 @@ bool pwrctl_set_vout(uint32_t value_mv);
 bool pwrctl_set_iout(uint32_t value_mv);
 
 /**
+  * @brief Get current output setting
+  * @retval current setting in milli amps
+  */
+uint32_t pwrctl_get_iout(void);
+
+/**
   * @brief Get voltage output setting
   * @retval current setting in millivolt
   */

--- a/opendps/pwrctl.h
+++ b/opendps/pwrctl.h
@@ -29,6 +29,7 @@
 #define __PWRCTL_H__
 
 extern uint32_t pwrctl_i_limit_raw;
+extern uint64_t pwr_start;
 
 /**
   * @brief Initialize the power control module

--- a/opendps/spi_driver.c
+++ b/opendps/spi_driver.c
@@ -29,6 +29,7 @@
 #include <spi.h>
 #include <stdio.h>
 #include <errno.h>
+#include "hw.h"
 #include "spi_driver.h"
 
 /** Used to keep track of the SPI DMA status */
@@ -89,6 +90,9 @@ bool spi_dma_transceive(uint8_t *tx_buf, uint32_t tx_len, uint8_t *rx_buf, uint3
         temp = SPI_DR(SPI2);
     }
 
+#ifdef TFT_CSN_PORT
+    gpio_clear(TFT_CSN_PORT, TFT_CSN_PIN);
+#endif
     dma_status = spi_idle;
 
     if (rx_len) {
@@ -136,6 +140,9 @@ bool spi_dma_transceive(uint8_t *tx_buf, uint32_t tx_len, uint8_t *rx_buf, uint3
     while (dma_status != spi_idle) ;
     while (!(SPI_SR(SPI2) & SPI_SR_TXE)) ;
     while (SPI_SR(SPI2) & SPI_SR_BSY) ;
+#ifdef TFT_CSN_PORT
+    gpio_set(TFT_CSN_PORT, TFT_CSN_PIN);
+#endif
 
 #ifndef SPI_NSS_GROUNDED
     gpio_set(GPIOB, GPIO12);

--- a/opendps/ui.c
+++ b/opendps/ui.c
@@ -110,9 +110,6 @@ static wifi_status_t wifi_status;
 static bool is_locked;
 static bool is_enabled;
 
-/** Time at wich V_out was enabled */
-static uint64_t pwr_start;
-
 /** Last settings written to past */
 static uint32_t     last_vout_setting;
 static uint32_t     last_ilimit_setting;

--- a/opendps/ui.h
+++ b/opendps/ui.h
@@ -35,6 +35,7 @@ typedef enum {
         pm_min = 0,
         pm_constant_voltage = pm_min,
         pm_constant_current,
+        pm_current_limit,
         pm_max
 } power_mode_t;
 


### PR DESCRIPTION
Hello. I made support for DPS5015. And now it almost usable. 
Also CC + CV mode (as in original DPS firmware) which is userful in many cases. I didn't made changes for binary protocol support, but I made full support in text protocol. As for now there are few new commands:
cc - CC mode
cv - CV mode
cl - Current Limit mode (CV unless current less than setting, else CC mode)
u - set voltage (instead of v command)
i - set current
I changed stat, and now it showing complete state.
Also I moved coefficients and offsets for ADC and DAC (only for current yet) into dps-model.h to support different shunt. And described formulas to calculate factor and offset;
Also I added software debounce for power enable button.
I need your help with mode image, I bithacked CV image, to make a little bit different image, because I have no idea how to cook this images.  
As for now I have not fixed LCD hanging yet. But as temporary hack I make reinitialization of LCD in "on" CLI command. I will try to fix is this problem.
