### PR TITLE
Update LibOpenCM3 target to use correct config file

### DIFF
--- a/libopencm3.target.mk
+++ b/libopencm3.target.mk
@@ -30,7 +30,7 @@ ARCH_FLAGS	= -mthumb -mcpu=cortex-m3 $(FP_FLAGS) -mfix-cortex-m3-ldrd
 
 OOCD		?= openocd
 OOCD_INTERFACE	?= stlink-v2
-OOCD_TARGET	?= stm32f1
+OOCD_TARGET	?= stm32f1x
 
 ################################################################################
 # Black Magic Probe specific variables


### PR DESCRIPTION
LibOpenCM3.target.mk contained the OpenOCD target `stm32f1` which is not an existing config file on OpenOCD 0.10.0 (latest).
Correct this to `stm32f1x`.