### PR TITLE
Added support for building firmware images using docker.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,20 @@
+FROM fedora:28
+LABEL Description="OpenDPS firmware, built using GCC 7.1.0" 
+
+RUN dnf update -y && dnf install -y arm-none-eabi-gcc arm-none-eabi-newlib git make python sudo findutils
+
+ENV user opendps
+RUN useradd -d /home/$user -m -s /bin/bash $user
+RUN echo "$user ALL=(root) NOPASSWD:ALL" >> /etc/sudoers
+
+USER $user
+WORKDIR /home/$user
+RUN mkdir -pv code
+COPY . ./code/
+RUN sudo chown $user.$user -R /home/$user/code
+WORKDIR /home/$user/code/
+RUN git submodule init
+RUN git submodule update
+RUN make -j -C libopencm3
+RUN make -C opendps elf bin
+RUN make -C dpsboot elf bin

--- a/build_binaries.sh
+++ b/build_binaries.sh
@@ -6,7 +6,7 @@ set -e
 git rev-parse --short HEAD
 PROJECT=$(git rev-parse --short HEAD)
 echo "Building opendps git version: $PROJECT"
-docker build -t $PROJECT -f Dockerfile3 .
+docker build -t $PROJECT -f Dockerfile .
 
 CONTAINER_ID=$(docker create $PROJECT bash)
 echo "CONTAINER ID: $CONTAINER_ID"

--- a/build_binaries.sh
+++ b/build_binaries.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+# Builds OpenDPS binaries in docker and then copies it over to host machine
+
+set -e
+git rev-parse --short HEAD
+PROJECT=$(git rev-parse --short HEAD)
+echo "Building opendps git version: $PROJECT"
+docker build -t $PROJECT -f Dockerfile3 .
+
+CONTAINER_ID=$(docker create $PROJECT bash)
+echo "CONTAINER ID: $CONTAINER_ID"
+docker cp $CONTAINER_ID:/home/opendps/code/opendps/opendps.elf ./opendps/opendps.elf
+docker cp $CONTAINER_ID:/home/opendps/code/opendps/opendps.bin ./opendps/opendps.bin
+docker cp $CONTAINER_ID:/home/opendps/code/dpsboot/dpsboot.elf ./dpsboot/dpsboot.elf
+docker cp $CONTAINER_ID:/home/opendps/code/dpsboot/dpsboot.bin ./dpsboot/dpsboot.bin
+docker rm $CONTAINER_ID


### PR DESCRIPTION
As discussed in #45 some users are having trouble building the firmware images due to OpenDPS favouring specific versions of GCC. ( Somewhere between these bounds: Greater than 5.4 and less than 8.1 )

This adds a simple script which allows any user with docker installed to compile the firmware images, as it creates a container which will compile the firmware with GCC 7.1.0. The end result is that the binaries appear in their respective folders and the user can carry on with flashing the firmware.

This is based on work originally by @zoobab which I've extended.

