### PR TITLE
Coloured fonts

### DIFF
--- a/opendps/Makefile
+++ b/opendps/Makefile
@@ -27,6 +27,11 @@ DEBUG ?= 0
 # Color space for the DPS display. Most units use GBR but RGB has been spotted in the wild
 COLORSPACE ?= 0
 
+# Colors for the main UI elements -- see ili9163c.h for list of colors
+COLOR_VOLTAGE ?= WHITE
+COLOR_AMPERAGE ?= WHITE
+COLOR_INPUT ?= WHITE
+
 # Optional tinting for UI elements
 TINT ?= ffffff
 
@@ -38,7 +43,15 @@ CFLAGS = -I. -DGIT_VERSION=\"$(GIT_VERSION)\" -Wno-missing-braces
 
 # Output voltage and current limit are persisted in flash,
 # this is the default setting
-CFLAGS += -DCONFIG_DEFAULT_VOUT=5000 -DCONFIG_DEFAULT_ILIMIT=500 -DCONFIG_BAUDRATE=$(BAUDRATE) -DCOLORSPACE=$(COLORSPACE) -D$(MODEL)
+CFLAGS += \
+          -DCONFIG_DEFAULT_VOUT=5000 \
+          -DCONFIG_DEFAULT_ILIMIT=500 \
+          -DCONFIG_BAUDRATE=$(BAUDRATE) \
+          -DCOLORSPACE=$(COLORSPACE) \
+          -DCOLOR_VOLTAGE=$(COLOR_VOLTAGE) \
+          -DCOLOR_AMPERAGE=$(COLOR_AMPERAGE) \
+          -DCOLOR_INPUT=$(COLOR_INPUT) \
+          -D$(MODEL)
 
 # Application linker script
 LDSCRIPT = stm32f100_app.ld
@@ -62,7 +75,7 @@ OBJS = \
     mini-printf.o \
     font-18.o \
     font-24.o \
-    font-48.o 
+    font-48.o
 
 ifdef MAX_CURRENT
 	CFLAGS +=-DCONFIG_DPS_MAX_CURRENT=$(MAX_CURRENT)

--- a/opendps/mini-printf.c
+++ b/opendps/mini-printf.c
@@ -104,11 +104,11 @@ mini_vsnprintf(char *buffer, unsigned int buffer_len, const char *fmt, va_list v
 	char bf[24];
 	char ch;
 
-	int _putc(char ch)
+	int _putc(char ch2)
 	{
 		if ((unsigned int)((pbuffer - buffer) + 1) >= buffer_len)
 			return 0;
-		*(pbuffer++) = ch;
+		*(pbuffer++) = ch2;
 		*(pbuffer) = '\0';
 		return 1;
 	}

--- a/opendps/opendps.c
+++ b/opendps/opendps.c
@@ -156,6 +156,7 @@ ui_number_t input_voltage = {
         .can_focus = false,
     },
     .font_size = 18,
+    .color = COLOR_INPUT,
     .value = 0,
     .min = 0,
     .max = 0,

--- a/opendps/tft.h
+++ b/opendps/tft.h
@@ -1,18 +1,18 @@
-/* 
+/*
  * The MIT License (MIT)
- * 
+ *
  * Copyright (c) 2017 Johan Kanflo (github.com/kanflo)
- * 
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
  * in the Software without restriction, including without limitation the rights
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be included in
  * all copies or substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -56,10 +56,11 @@ void tft_blit(uint16_t *bits, uint32_t width, uint32_t height, uint32_t x, uint3
   * @param y y position
   * @param w width of bounding box
   * @param h height of bounding box
+  * @param color color of the glyph
   * @param highlight if true, the character will be inverted
   * @retval none
   */
-void tft_putch(uint8_t size, char ch, uint32_t x, uint32_t y, uint32_t w, uint32_t h, bool highlight);
+void tft_putch(uint8_t size, char ch, uint32_t x, uint32_t y, uint32_t w, uint32_t h, uint16_t color, bool highlight);
 
 /**
   * @brief Fill area with specified pattern

--- a/opendps/uui_number.c
+++ b/opendps/uui_number.c
@@ -127,14 +127,18 @@ static void number_draw(ui_item_t *_item)
         w = font_48_widths[4] + 2; /** @todo: Find the widest glyph */
         h = font_48_height + 2;
         break;
+      default:
+        /* Can't do anything if the wrong font size was supplied. Drop out for safety. */
+        return;
     }
     uint16_t xpos = _item->x - w;
+    uint16_t color = item->color;
     switch(item->unit) {
         case unit_volt:
-            tft_putch(item->font_size, 'V', xpos, _item->y, w, h, false);
+            tft_putch(item->font_size, 'V', xpos, _item->y, w, h, color, false);
             break;
         case unit_ampere:
-            tft_putch(item->font_size, 'A', xpos, _item->y, w, h, false);
+            tft_putch(item->font_size, 'A', xpos, _item->y, w, h, color, false);
             break;
         default:
             assert(0);
@@ -143,16 +147,16 @@ static void number_draw(ui_item_t *_item)
     for (uint32_t i = 0; i < item->num_decimals; i++) {
         bool highlight = _item->has_focus && item->cur_digit == cur_digit;
         xpos -= w;
-        tft_putch(item->font_size, '0'+(value%10), xpos, _item->y, w, h, highlight);
+        tft_putch(item->font_size, '0'+(value%10), xpos, _item->y, w, h, color, highlight);
         value /= 10;
         cur_digit++;
     }
     xpos -= item->font_size == 18 ? 4 : 10;
-    tft_putch(item->font_size, '.', xpos, _item->y, item->font_size == 18 ? 4 : 10, h, false);
+    tft_putch(item->font_size, '.', xpos, _item->y, item->font_size == 18 ? 4 : 10, h, color, false);
     for (uint32_t i = 0; i < item->num_digits; i++) {
         bool highlight = _item->has_focus && item->cur_digit == cur_digit;
         xpos -= w;
-        tft_putch(item->font_size, '0'+(value%10), xpos, _item->y, w, h, highlight);
+        tft_putch(item->font_size, '0'+(value%10), xpos, _item->y, w, h, color, highlight);
         value /= 10;
         cur_digit++;
         if (!value && !_item->has_focus) { /** To prevent from printing 00.123 */

--- a/opendps/uui_number.h
+++ b/opendps/uui_number.h
@@ -39,6 +39,7 @@
 typedef struct ui_number_t {
     ui_item_t ui;
     unit_t unit;
+    uint16_t color;
     uint8_t font_size;
     uint8_t num_digits;
     uint8_t num_decimals;


### PR DESCRIPTION
As per the discussion on the blog post -- added support for different coloured meters on the screen.

Replaced the existing conversion code for fonts/graphics as well -- my build machine had serious problems with the latest ImageMagick, so it seemed like the easiest solution was to DIY it. No piping between multiple programs -- load input PNG and export the corresponding rgb565 data.