### PR TITLE
Set DPS max current from MODEL specified in makefile

### DIFF
--- a/opendps/Makefile
+++ b/opendps/Makefile
@@ -14,7 +14,8 @@ SPLASH_SCREEN := 0
 WIFI := 1
 
 # Maximum current your DPS model can provide. Eg 5000mA for the DPS5005
-MAX_CURRENT := 5000
+# This is usually set by MODEL but you can override it here
+#MAX_CURRENT := 5000
 # Please note that the UI currently does not handle settings larger that 9.99A
 
 # Color space for the DPS display. Most units use GBR but RGB has been spotted in the wild
@@ -27,7 +28,7 @@ TINT ?= ffffff
 CC_ENABLE ?= 1
 
 GIT_VERSION := $(shell git describe --abbrev=4 --dirty --always --tags)
-CFLAGS = -I. -DCONFIG_DPS_MAX_CURRENT=$(MAX_CURRENT) -DGIT_VERSION=\"$(GIT_VERSION)\" -Wno-missing-braces
+CFLAGS = -I. -DGIT_VERSION=\"$(GIT_VERSION)\" -Wno-missing-braces
 
 # Output voltage and current limit are persisted in flash,
 # this is the default setting
@@ -56,6 +57,10 @@ OBJS = \
     mini-printf.o \
     font-0.o \
     font-1.o
+
+ifdef MAX_CURRENT
+	CFLAGS +=-DCONFIG_DPS_MAX_CURRENT=$(MAX_CURRENT)
+endif
 
 ifeq ($(CC_ENABLE),1)
 	CFLAGS +=-DCONFIG_CC_ENABLE

--- a/opendps/dps-model.h
+++ b/opendps/dps-model.h
@@ -43,6 +43,9 @@
 
 /** Contribution by @cleverfox */
 #if defined(DPS5015)
+ #ifndef CONFIG_DPS_MAX_CURRENT
+  #define CONFIG_DPS_MAX_CURRENT (15000) // Please note that the UI currently does not handle settings larger that 9.99A
+ #endif
  #define ADC_CHA_IOUT_GOLDEN_VALUE  (59)
  #define A_ADC_K (double)6.8403
  #define A_ADC_C (double)-394.06
@@ -53,6 +56,9 @@
  #define V_DAC_K (double)0.072266
  #define V_DAC_C (double)4.444777
 #elif defined(DPS5005)
+ #ifndef CONFIG_DPS_MAX_CURRENT
+  #define CONFIG_DPS_MAX_CURRENT (5000)
+ #endif
  #define ADC_CHA_IOUT_GOLDEN_VALUE  (0x45)
  #define A_ADC_K (double)1.713
  #define A_ADC_C (double)-118.51
@@ -63,6 +69,9 @@
  #define V_ADC_K (double)13.164
  #define V_ADC_C (double)-100.751
 #elif defined(DPS3005)
+ #ifndef CONFIG_DPS_MAX_CURRENT
+  #define CONFIG_DPS_MAX_CURRENT (5000)
+ #endif
  #define ADC_CHA_IOUT_GOLDEN_VALUE  (0x00)
  #define A_ADC_K (double)1.751
  #define A_ADC_C (double)-1.101


### PR DESCRIPTION
Set the CONFIG_DPS_MAX_CURRENT #define based on the MODEL chosen. You can however override this if you so wish.
This was based on the following comment: https://github.com/kanflo/opendps/issues/45#issuecomment-435242383

I haven't tested if this compiles as I don't have my toolchain with me...