### PR TITLE
Allow changing of baudrate at compile time

### DIFF
--- a/dpsboot/Makefile
+++ b/dpsboot/Makefile
@@ -1,7 +1,10 @@
 BINARY = dpsboot
 
+# The baudrate used for serial communications, defaults to 115200
+BAUDRATE ?= 115200
+
 GIT_VERSION := $(shell git describe --abbrev=4 --dirty --always --tags)
-CFLAGS = -I. -I../opendps -DGIT_VERSION=\"$(GIT_VERSION)\" -DCONFIG_PAST_NO_GC
+CFLAGS = -I. -I../opendps -DGIT_VERSION=\"$(GIT_VERSION)\" -DCONFIG_PAST_NO_GC -DCONFIG_BAUDRATE=$(BAUDRATE)
 # Future optimisation: saves ~600 bytes but does not work for gcc <= 7
 #CFLAGS += -flto
 

--- a/dpsboot/hw.c
+++ b/dpsboot/hw.c
@@ -113,7 +113,7 @@ static void usart_init(void)
     gpio_set_mode(GPIOA, GPIO_MODE_INPUT, GPIO_CNF_INPUT_FLOAT, GPIO_USART1_RX);
 
     nvic_enable_irq(NVIC_USART1_IRQ);
-    usart_set_baudrate(USART1, 115200);
+    usart_set_baudrate(USART1, CONFIG_BAUDRATE); /** Baudrate set in makefile */
     usart_set_databits(USART1, 8);
     usart_set_stopbits(USART1, USART_STOPBITS_1);
     usart_set_mode(USART1, USART_MODE_TX_RX);

--- a/dpsctl/dpsctl.py
+++ b/dpsctl/dpsctl.py
@@ -92,13 +92,15 @@ A class that describes a serial interface
 class tty_interface(comm_interface):
 
     _port_handle = None
+    _baudrate = None
 
-    def __init__(self, if_name):
+    def __init__(self, if_name, baudrate):
         self._if_name = if_name
+        self._baudrate = baudrate
 
     def open(self):
         if not self._port_handle:
-            self._port_handle = serial.Serial(baudrate = 115200, timeout = 1.0)
+            self._port_handle = serial.Serial(baudrate = self._baudrate, timeout = 1.0)
             self._port_handle.port = self._if_name
             self._port_handle.open()
         return True
@@ -502,7 +504,7 @@ def create_comms(args):
         if is_ip_address(if_name):
             comms = udp_interface(if_name)
         else:
-            comms = tty_interface(if_name)
+            comms = tty_interface(if_name, args.baudrate)
     else:
         fail("no comms interface specified")
     return comms
@@ -591,6 +593,7 @@ def main():
     parser = argparse.ArgumentParser(description='Instrument an OpenDPS device')
 
     parser.add_argument('-d', '--device', help="OpenDPS device to connect to. Can be a /dev/tty device or an IP number. If omitted, dpsctl.py will try the environment variable DPSIF", default='')
+    parser.add_argument('-b', '--baudrate', type=int, dest="baudrate", help="Set baudrate used for serial communications", default=115200)
     parser.add_argument('-S', '--scan', action="store_true", help="Scan for OpenDPS wifi devices")
     parser.add_argument('-f', '--function', nargs='?', help="Set active function")
     parser.add_argument('-F', '--list-functions', action='store_true', help="List available functions")

--- a/esp8266-proxy/Makefile
+++ b/esp8266-proxy/Makefile
@@ -1,6 +1,11 @@
 PROGRAM=dpsproxy
+
+# The baudrate used for serial communications, defaults to 115200
+BAUDRATE ?= 115200
+
 OTA=1
 EXTRA_COMPONENTS=extras/rboot-ota extras/stdin_uart_interrupt
 PROGRAM_INC_DIR = . ./../opendps ./uhej
 PROGRAM_SRC_DIR=. ./uhej
+PROGRAM_CFLAGS+=-DCONFIG_BAUDRATE=$(BAUDRATE)
 include esp-open-rtos/common.mk

--- a/esp8266-proxy/dpsproxy.c
+++ b/esp8266-proxy/dpsproxy.c
@@ -327,7 +327,7 @@ static void wifi_task(void *pvParameters)
 
 void user_init(void)
 {
-    uart_set_baud(0, 115200);
+    uart_set_baud(0, CONFIG_BAUDRATE);  /** Baudrate set in makefile */
     uart_clear_txfifo(0);
     vSemaphoreCreateBinary(wifi_alive_sem);
     tx_queue = xQueueCreate(TX_QUEUE_DEPTH, sizeof(tx_item_t));

--- a/opendps/Makefile
+++ b/opendps/Makefile
@@ -3,6 +3,9 @@ BINARY = opendps
 # Build with commandline interface rather than serial interface
 COMMANDLINE := 0
 
+# The baudrate used for serial communications, defaults to 115200
+BAUDRATE ?= 115200
+
 # Set build model, defaults to DPS5005
 MODEL := DPS5005
 
@@ -32,7 +35,7 @@ CFLAGS = -I. -DGIT_VERSION=\"$(GIT_VERSION)\" -Wno-missing-braces
 
 # Output voltage and current limit are persisted in flash,
 # this is the default setting
-CFLAGS += -DCONFIG_DEFAULT_VOUT=5000 -DCONFIG_DEFAULT_ILIMIT=500 -DCOLORSPACE=$(COLORSPACE) -D$(MODEL)
+CFLAGS += -DCONFIG_DEFAULT_VOUT=5000 -DCONFIG_DEFAULT_ILIMIT=500 -DCONFIG_BAUDRATE=$(BAUDRATE) -DCOLORSPACE=$(COLORSPACE) -D$(MODEL)
 
 # Application linker script
 LDSCRIPT = stm32f100_app.ld

--- a/opendps/hw.c
+++ b/opendps/hw.c
@@ -363,7 +363,7 @@ static void usart_init(void)
     gpio_set_mode(GPIOA, GPIO_MODE_INPUT, GPIO_CNF_INPUT_FLOAT, GPIO_USART1_RX);
 
     nvic_enable_irq(NVIC_USART1_IRQ);
-    usart_set_baudrate(USART1, 115200);
+    usart_set_baudrate(USART1, CONFIG_BAUDRATE); /** Baudrate set in makefile */
     usart_set_databits(USART1, 8);
     usart_set_stopbits(USART1, USART_STOPBITS_1);
     usart_set_mode(USART1, USART_MODE_TX_RX);


### PR DESCRIPTION
This allows the changing of the serial baudrate used via the makefile e.g. `make BAUDRATE=9600`

It also allows a user defined baudrate to be used by dpsctl e.g. `python dpsctl.py -b 9600` or `python dpsctl.py --baudrate 9600`

I haven't tested the esp8266 stuff as I don't have the toolchain or the device but I believe this is the correct way to do it

This is to close #60 