### PR TITLE
Protect from negative values and apply correct rounding

### DIFF
--- a/opendps/dps-model.h
+++ b/opendps/dps-model.h
@@ -85,6 +85,10 @@
  #error "Please set MODEL to the device you want to build for"
 #endif // MODEL
 
+/** These are constant across all models currently but may require tuning for each model */
+#define VIN_ADC_K (double)16.746
+#define VIN_ADC_C (double)64.112
+
 #define VIN_VOUT_RATIO (float)1.1f /** (Vin / VIN_VOUT_RATIO) = Max Vout */
 
 #endif // __DPS_MODEL_H__


### PR DESCRIPTION
This will solve any off by one rounding errors that were occuring from the floating point calculation being truncated when it is returned.

I have also put in protection from negative values as casting from a negative float to an unsigned int is undefined behaviour

I've also removed the VIN K and C magic numbers and moved them to dps_model.h. This should help us support more models more easily in the future