### PR TITLE
Fix undefined behaviour and allow n-length strings

### DIFF
--- a/dpsboot/dpsboot.c
+++ b/dpsboot/dpsboot.c
@@ -302,9 +302,16 @@ int main(void)
 #ifdef GIT_VERSION
         /** Update boot git hash in past if needed */
         char *ver = 0;
-        uint32_t foo;
-        bool exists = past_read_unit(&past, past_boot_git_hash, (const void**) &ver, &foo);
-        if (!exists || strncmp((char*) ver, GIT_VERSION, 32 /* probably never longer than 32 bytes */) != 0) {
+        bool exists = past_read_unit(&past, past_boot_git_hash, (const void**) &ver, &length);
+
+        if (!exists) /** If hash isn't stored in past then write it in */
+        {
+            if (!past_write_unit(&past, past_boot_git_hash, (void*) &GIT_VERSION, strlen(GIT_VERSION))) {
+                /** @todo Handle past write errors */
+            }
+        }
+        else if (strncmp(ver, GIT_VERSION, length) != 0) //** Else if hash is stored in past but is different then update it */
+        {
             if (!past_write_unit(&past, past_boot_git_hash, (void*) &GIT_VERSION, strlen(GIT_VERSION))) {
                 /** @todo Handle past write errors */
             }

--- a/dpsboot/dpsboot.c
+++ b/dpsboot/dpsboot.c
@@ -310,7 +310,7 @@ int main(void)
                 /** @todo Handle past write errors */
             }
         }
-        else if (strncmp(ver, GIT_VERSION, length) != 0) //** Else if hash is stored in past but is different then update it */
+        else if (strncmp(ver, GIT_VERSION, length) != 0) /** Else if hash is stored in past but is different then update it */
         {
             if (!past_write_unit(&past, past_boot_git_hash, (void*) &GIT_VERSION, strlen(GIT_VERSION))) {
                 /** @todo Handle past write errors */

--- a/opendps/opendps.c
+++ b/opendps/opendps.c
@@ -683,10 +683,17 @@ static void read_past_settings(void)
     /** Update app git hash in past if needed */
     char *ver = 0;
     bool exists = past_read_unit(&g_past, past_app_git_hash, (const void**) &ver, &length);
-    if (!exists || strncmp((char*) ver, GIT_VERSION, 32 /* probably never longer than 32 bytes */) != 0) {
+    
+    if (!exists) /** If hash isn't stored in past then write it in */
+    {
         if (!past_write_unit(&g_past, past_app_git_hash, (void*) &GIT_VERSION, strlen(GIT_VERSION))) {
-            /** @todo Handle past write errors */
-            dbg_printf("Error: past write app git hash failed!\n");
+            dbg_printf("Error: past write app git hash failed!\n"); /** @todo Handle past write errors */
+        }
+    }
+    else if (strncmp(ver, GIT_VERSION, length) != 0) //** Else if hash is stored in past but is different then update it */
+    {
+        if (!past_write_unit(&g_past, past_app_git_hash, (void*) &GIT_VERSION, strlen(GIT_VERSION))) {
+            dbg_printf("Error: past write app git hash failed!\n"); /** @todo Handle past write errors */
         }
     }
 #endif // GIT_VERSION

--- a/opendps/opendps.c
+++ b/opendps/opendps.c
@@ -683,14 +683,14 @@ static void read_past_settings(void)
     /** Update app git hash in past if needed */
     char *ver = 0;
     bool exists = past_read_unit(&g_past, past_app_git_hash, (const void**) &ver, &length);
-    
+
     if (!exists) /** If hash isn't stored in past then write it in */
     {
         if (!past_write_unit(&g_past, past_app_git_hash, (void*) &GIT_VERSION, strlen(GIT_VERSION))) {
             dbg_printf("Error: past write app git hash failed!\n"); /** @todo Handle past write errors */
         }
     }
-    else if (strncmp(ver, GIT_VERSION, length) != 0) //** Else if hash is stored in past but is different then update it */
+    else if (strncmp(ver, GIT_VERSION, length) != 0) /** Else if hash is stored in past but is different then update it */
     {
         if (!past_write_unit(&g_past, past_app_git_hash, (void*) &GIT_VERSION, strlen(GIT_VERSION))) {
             dbg_printf("Error: past write app git hash failed!\n"); /** @todo Handle past write errors */


### PR DESCRIPTION
`strncmp` of a null is undefined behaviour and shouldn't be used

This also allows any length of GIT_VERSION