### PR TITLE
Add calibration report command

### DIFF
--- a/dpsctl/dpsctl.py
+++ b/dpsctl/dpsctl.py
@@ -337,6 +337,8 @@ def handle_response(command, frame, args):
         data = unpack_version_response(frame)
         print("BootDPS GIT Hash: %s" % data['boot_git_hash'])
         print("OpenDPS GIT Hash: %s" % data['app_git_hash'])
+    elif resp_command == cmd_cal_report:
+        ret_dict = unpack_cal_report(frame)
     else:
         print("Unknown response %d from device." % (resp_command))
 
@@ -423,6 +425,25 @@ def handle_commands(args):
 
     if args.version:
         communicate(comms, create_cmd(cmd_version), args)
+
+    if args.calibration_report:
+        data = communicate(comms, create_cmd(cmd_cal_report), args)
+        print("Calibration Report:")
+        print("\tA_ADC_K = {}".format(data['cal']['A_ADC_K']))
+        print("\tA_ADC_C = {}".format(data['cal']['A_ADC_C']))
+        print("\tA_DAC_K = {}".format(data['cal']['A_DAC_K']))
+        print("\tA_DAC_C = {}".format(data['cal']['A_DAC_C']))
+        print("\tV_ADC_K = {}".format(data['cal']['V_ADC_K']))
+        print("\tV_ADC_C = {}".format(data['cal']['V_ADC_C']))
+        print("\tV_DAC_K = {}".format(data['cal']['V_DAC_K']))
+        print("\tV_DAC_C = {}".format(data['cal']['V_DAC_C']))
+        print("\tVIN_ADC_K = {}".format(data['cal']['VIN_ADC_K']))
+        print("\tVIN_ADC_C = {}".format(data['cal']['VIN_ADC_C']))
+        print("\tVIN_ADC = {}".format(data['vin_adc']))
+        print("\tVOUT_ADC = {}".format(data['vout_adc']))
+        print("\tIOUT_ADC = {}".format(data['iout_adc']))
+        print("\tIOUT_DAC = {}".format(data['iout_dac']))
+        print("\tVOUT_DAC = {}".format(data['vout_dac']))
 
     if hasattr(args, 'temperature') and args.temperature:
         communicate(comms, create_temperature(float(args.temperature)), args)
@@ -605,6 +626,7 @@ def main():
     parser.add_argument('-F', '--list-functions', action='store_true', help="List available functions")
     parser.add_argument('-p', '--parameter', nargs='+', help="Set function parameter <name>=<value>")
     parser.add_argument('-P', '--list-parameters', action='store_true', help="List function parameters of active function")
+    parser.add_argument('-cr','--calibration_report', action="store_true", help="Prints Calibration report")
     parser.add_argument('-o', '--enable', help="Enable output ('on' or 'off')")
     parser.add_argument(      '--ping', action='store_true', help="Ping device (causes screen to flash)")
     parser.add_argument('-L', '--lock', action='store_true', help="Lock device keys")

--- a/dpsctl/protocol.py
+++ b/dpsctl/protocol.py
@@ -23,6 +23,7 @@ THE SOFTWARE.
 """
 
 from uframe import *
+import struct
 
 # command_t
 cmd_ping = 1
@@ -42,6 +43,7 @@ cmd_set_parameters = 14
 cmd_list_parameters = 15
 cmd_temperature_report = 16
 cmd_version = 17
+cmd_cal_report = 18
 cmd_response = 0x80
 
 # wifi_status_t
@@ -216,6 +218,29 @@ def unpack_query_response(uframe):
         value = uframe.unpack_cstr()
         data['params'][key] = value
     return data
+
+# Returns ADC/DAC values and calibration values
+def unpack_cal_report(uframe):
+    data = {}
+    data['cal']= {}
+    data['command'] = uframe.unpack8()
+    data['status'] = uframe.unpack8()
+    data['vout_adc'] = uframe.unpack16()
+    data['vin_adc'] = uframe.unpack16()
+    data['iout_adc'] = uframe.unpack16()
+    data['iout_dac'] = uframe.unpack16()
+    data['vout_dac'] = uframe.unpack16()
+    data['cal']['A_ADC_K'] = struct.unpack("<f", struct.pack("<I", uframe.unpack32()))[0]
+    data['cal']['A_ADC_C'] = struct.unpack("<f", struct.pack("<I", uframe.unpack32()))[0]
+    data['cal']['A_DAC_K'] = struct.unpack("<f", struct.pack("<I", uframe.unpack32()))[0]
+    data['cal']['A_DAC_C'] = struct.unpack("<f", struct.pack("<I", uframe.unpack32()))[0]
+    data['cal']['V_ADC_K'] = struct.unpack("<f", struct.pack("<I", uframe.unpack32()))[0]
+    data['cal']['V_ADC_C'] = struct.unpack("<f", struct.pack("<I", uframe.unpack32()))[0]
+    data['cal']['V_DAC_K'] = struct.unpack("<f", struct.pack("<I", uframe.unpack32()))[0]
+    data['cal']['V_DAC_C'] = struct.unpack("<f", struct.pack("<I", uframe.unpack32()))[0]
+    data['cal']['VIN_ADC_K'] = struct.unpack("<f", struct.pack("<I", uframe.unpack32()))[0]
+    data['cal']['VIN_ADC_C'] = struct.unpack("<f", struct.pack("<I", uframe.unpack32()))[0]
+    return data 
 
 # Returns wifi_status
 def unpack_wifi_status(uframe):

--- a/opendps/protocol.h
+++ b/opendps/protocol.h
@@ -54,6 +54,7 @@ typedef enum {
     cmd_list_parameters,
     cmd_temperature_report,
     cmd_version,
+    cmd_cal_report,
     cmd_response = 0x80
 } command_t;
 

--- a/opendps/protocol_handler.c
+++ b/opendps/protocol_handler.c
@@ -28,7 +28,9 @@
 #include <string.h>
 #include <stdlib.h>
 #include <scb.h>
+#include <dac.h>
 #include "dbg_printf.h"
+#include "dps-model.h"
 #include "hw.h"
 #include "uui.h"
 #include "pwrctl.h"

--- a/opendps/protocol_handler.c
+++ b/opendps/protocol_handler.c
@@ -312,6 +312,38 @@ static command_status_t handle_version(void)
 }
 
 /**
+  * @brief Handle a cal report
+  * @retval command_status_t failed, success or "I sent my own frame"
+  */
+static command_status_t handle_cal_report(void)
+{
+    uint16_t i_out_raw, v_in_raw, v_out_raw;
+    hw_get_adc_values(&i_out_raw, &v_in_raw, &v_out_raw);
+
+    DECLARE_FRAME(64);
+    PACK8(cmd_response | cmd_cal_report);
+    PACK8(1); 
+    PACK16(v_out_raw);
+    PACK16(v_in_raw);
+    PACK16(i_out_raw);
+    PACK16(DAC_DHR12R2);
+    PACK16(DAC_DHR12R1);
+    PACKFLOAT(A_ADC_K);
+    PACKFLOAT(A_ADC_C);
+    PACKFLOAT(A_DAC_K);
+    PACKFLOAT(A_DAC_C);
+    PACKFLOAT(V_ADC_K);
+    PACKFLOAT(V_ADC_C);
+    PACKFLOAT(V_DAC_K);
+    PACKFLOAT(V_DAC_C);
+    PACKFLOAT(VIN_ADC_K);
+    PACKFLOAT(VIN_ADC_C);
+    FINISH_FRAME();
+    send_frame(_buffer, _length);
+    return cmd_success_but_i_actually_sent_my_own_status_thank_you_very_much;
+}
+
+/**
   * @brief Handle a wifi status command
   * @param payload payload of command frame
   * @param payload_len length of payload
@@ -420,6 +452,10 @@ static void handle_frame(uint8_t *frame, uint32_t length)
                 break;
             case cmd_version:
                 success = handle_version();
+                break;
+            case cmd_cal_report:
+                success = handle_cal_report();
+                break;
             default:
                 emu_printf("Got unknown command %d (0x%02x)\n", cmd, cmd);
                 break;

--- a/opendps/uframe.h
+++ b/opendps/uframe.h
@@ -87,6 +87,16 @@
     PACK8(((w) >> 8) & 0xff); \
     PACK8((w) & 0xff);
 
+#define PACKFLOAT(w) \
+    { \
+        union { \
+            float f; \
+            uint32_t ui; \
+        } overlay; \
+        overlay.f = w; \
+        PACK32(overlay.ui); \
+    }
+
 /** Like PACK8 but does not compute crc */
 #define STUFF8(b) \
     if (_length+2 < sizeof(_buffer)) { \


### PR DESCRIPTION
Add a way of fetching the K and C constants as well as the current ADC and DAC values.
This will be very useful for calibrating and debugging devices as discussed in #68 

I haven't checked if this functions correctly as I've cherrypicked it from commits on my work for #17 

This is used like so:
```
python dpsctl.py -d COM7 -cr
Calibration Report:
        A_ADC_K = 1.71300005913
        A_ADC_C = -118.510002136
        A_DAC_K = 0.652000010014
        A_DAC_C = 288.610992432
        V_ADC_K = 13.1639995575
        V_ADC_C = -100.750999451
        V_DAC_K = 0.0719999969006
        V_DAC_C = 1.85000002384
        VIN_ADC_K = 16.7460002899
        VIN_ADC_C = 64.1119995117
        VIN_ADC = 913
        VOUT_ADC = 7
        IOUT_ADC = 0
        IOUT_DAC = 0
        VOUT_DAC = 0
```