### PR TITLE
Add warning about past_boot_git_hash enum value

### DIFF
--- a/opendps/pastunits.h
+++ b/opendps/pastunits.h
@@ -32,7 +32,7 @@ typedef enum {
     /** stored as 0 or 1 */
     past_tft_inversion,
     /** stored as strings */
-    past_boot_git_hash,
+    past_boot_git_hash, /** WARN: Moving past_boot_git_hash requires a recompile and flash of DPSBoot! */
     past_app_git_hash,
     /** A past unit who's precense indicates we have a non finished upgrade and
     must not boot */


### PR DESCRIPTION
If past_boot_git_hash changes value from 3 a recompile and reflash of dpsboot would be required.
It is best to avoid doing this if necessary so I've added in a comment to stress this fact