### PR TITLE
Set/Clear coefficients from python

### DIFF
--- a/dpsctl/protocol.py
+++ b/dpsctl/protocol.py
@@ -44,6 +44,8 @@ cmd_list_parameters = 15
 cmd_temperature_report = 16
 cmd_version = 17
 cmd_cal_report = 18
+cmd_set_calibration = 19
+cmd_clear_calibration = 20
 cmd_response = 0x80
 
 # wifi_status_t
@@ -105,6 +107,21 @@ def create_set_parameter(parameter_list):
         else:
             f.pack_cstr(parts[0].lstrip().rstrip())
             f.pack_cstr(parts[1].lstrip().rstrip())
+    f.end()
+    return f
+
+def create_set_calibration(parameter_list):
+    f = uFrame()
+    f.pack8(cmd_set_calibration)
+    for p in parameter_list:
+        parts = p.split("=")
+        if len(parts) != 2:
+            return None
+        else:
+            f.pack_cstr(parts[0].lstrip().rstrip())
+            for t in bytearray(struct.pack("f",float(parts[1].lstrip().rstrip()))):
+                f.pack8(t)
+    f.pack8(0)
     f.end()
     return f
 

--- a/opendps/dps-model.h
+++ b/opendps/dps-model.h
@@ -47,47 +47,47 @@
   #define CONFIG_DPS_MAX_CURRENT (15000) // Please note that the UI currently does not handle settings larger that 9.99A
  #endif
  #define ADC_CHA_IOUT_GOLDEN_VALUE  (59)
- #define A_ADC_K (double)6.8403
- #define A_ADC_C (double)-394.06
- #define A_DAC_K (double)0.166666
- #define A_DAC_C (double)261.6666
- #define V_ADC_K (double)13.012
- #define V_ADC_C (double)-125.732
- #define V_DAC_K (double)0.072266
- #define V_DAC_C (double)4.444777
+ #define A_ADC_K (float)6.8403f
+ #define A_ADC_C (float)-394.06f
+ #define A_DAC_K (float)0.166666f
+ #define A_DAC_C (float)261.6666f
+ #define V_ADC_K (float)13.012f
+ #define V_ADC_C (float)-125.732f
+ #define V_DAC_K (float)0.072266f
+ #define V_DAC_C (float)4.444777f
 #elif defined(DPS5005)
  #ifndef CONFIG_DPS_MAX_CURRENT
   #define CONFIG_DPS_MAX_CURRENT (5000)
  #endif
  #define ADC_CHA_IOUT_GOLDEN_VALUE  (0x45)
- #define A_ADC_K (double)1.713
- #define A_ADC_C (double)-118.51
- #define A_DAC_K (double)0.652
- #define A_DAC_C (double)288.611
- #define V_DAC_K (double)0.072
- #define V_DAC_C (double)1.85
- #define V_ADC_K (double)13.164
- #define V_ADC_C (double)-100.751
+ #define A_ADC_K (float)1.713f
+ #define A_ADC_C (float)-118.51f
+ #define A_DAC_K (float)0.652f
+ #define A_DAC_C (float)288.611f
+ #define V_DAC_K (float)0.072f
+ #define V_DAC_C (float)1.85f
+ #define V_ADC_K (float)13.164f
+ #define V_ADC_C (float)-100.751f
 #elif defined(DPS3005)
  #ifndef CONFIG_DPS_MAX_CURRENT
   #define CONFIG_DPS_MAX_CURRENT (5000)
  #endif
  #define ADC_CHA_IOUT_GOLDEN_VALUE  (0x00)
- #define A_ADC_K (double)1.751
- #define A_ADC_C (double)-1.101
- #define A_DAC_K (double)0.653
- #define A_DAC_C (double)262.5
- #define V_DAC_K (double)0.0761
- #define V_DAC_C (double)2.2857
- #define V_ADC_K (double)13.131
- #define V_ADC_C (double)-111.9
+ #define A_ADC_K (float)1.751f
+ #define A_ADC_C (float)-1.101f
+ #define A_DAC_K (float)0.653f
+ #define A_DAC_C (float)262.5f
+ #define V_DAC_K (float)0.0761f
+ #define V_DAC_C (float)2.2857f
+ #define V_ADC_K (float)13.131f
+ #define V_ADC_C (float)-111.9f
 #else
  #error "Please set MODEL to the device you want to build for"
 #endif // MODEL
 
 /** These are constant across all models currently but may require tuning for each model */
-#define VIN_ADC_K (double)16.746
-#define VIN_ADC_C (double)64.112
+#define VIN_ADC_K (float)16.746f
+#define VIN_ADC_C (float)64.112f
 
 #define VIN_VOUT_RATIO (float)1.1f /** (Vin / VIN_VOUT_RATIO) = Max Vout */
 

--- a/opendps/opendps.c
+++ b/opendps/opendps.c
@@ -283,6 +283,75 @@ set_param_status_t opendps_set_parameter(char *name, char *value)
 }
 
 /**
+ * @brief      Sets Calibration Data
+ *
+ * @param      name Name of calibration variable to set
+ * @value      value Value to set it to
+ *
+ * @return     Status of the operation
+ */
+set_param_status_t opendps_set_calibration(char *name, float *value)
+{
+    past_id_t param;
+
+    if (strcmp(name,"A_ADC_K")==0){
+        param = past_A_ADC_K;
+    } else if(strcmp(name,"A_ADC_C")==0){
+        param = past_A_ADC_C;
+    } else if(strcmp(name,"A_DAC_K")==0){
+        param = past_A_DAC_K;
+    } else if(strcmp(name,"A_DAC_C")==0){
+        param = past_A_DAC_C;
+    } else if(strcmp(name,"V_ADC_K")==0){
+        param = past_V_DAC_K;
+    } else if(strcmp(name,"V_ADC_C")==0){
+        param = past_V_DAC_C;
+    } else if(strcmp(name,"V_DAC_K")==0){
+        param = past_V_ADC_K;
+    } else if(strcmp(name,"V_DAC_C")==0){
+        param = past_V_ADC_C;
+    } else if(strcmp(name,"VIN_ADC_K")==0){
+        param = past_VIN_ADC_K;
+    } else if(strcmp(name,"VIN_ADC_C")==0){
+        param = past_VIN_ADC_C;
+    } else {
+        return ps_not_supported;
+    }
+    
+    if (!past_write_unit(&g_past, param, (void*) value, sizeof(*value))) {
+        dbg_printf("Error: past write app git hash failed!\n");
+        return ps_flash_error;
+    }
+
+    /** Re-init pwrctl with new calibration coefs */
+    pwrctl_init(&g_past);
+    return ps_ok;
+}
+
+/**
+ * @brief      Clear Calibration Data
+ *
+ * @return     Status of the operation
+ */
+set_param_status_t opendps_clear_calibration(void)
+{
+    past_erase_unit(&g_past, past_A_ADC_K);
+    past_erase_unit(&g_past, past_A_ADC_C);
+    past_erase_unit(&g_past, past_A_DAC_K);
+    past_erase_unit(&g_past, past_A_DAC_C);
+    past_erase_unit(&g_past, past_V_DAC_K);
+    past_erase_unit(&g_past, past_V_DAC_C);
+    past_erase_unit(&g_past, past_V_ADC_K);
+    past_erase_unit(&g_past, past_V_ADC_C);
+    past_erase_unit(&g_past, past_VIN_ADC_K);
+    past_erase_unit(&g_past, past_VIN_ADC_C);
+
+    /** Re-init pwrctl as calibration coefs have now been cleared */
+    pwrctl_init(&g_past);
+    return ps_ok;
+}
+
+/**
  * @brief      Enable output of current function
  *
  * @param[in]  enable  Enable or disable

--- a/opendps/opendps.c
+++ b/opendps/opendps.c
@@ -331,9 +331,9 @@ set_param_status_t opendps_set_calibration(char *name, float *value)
 /**
  * @brief      Clear Calibration Data
  *
- * @return     Status of the operation
+ * @return     True on success
  */
-set_param_status_t opendps_clear_calibration(void)
+bool opendps_clear_calibration(void)
 {
     past_erase_unit(&g_past, past_A_ADC_K);
     past_erase_unit(&g_past, past_A_ADC_C);
@@ -348,7 +348,7 @@ set_param_status_t opendps_clear_calibration(void)
 
     /** Re-init pwrctl as calibration coefs have now been cleared */
     pwrctl_init(&g_past);
-    return ps_ok;
+    return true;
 }
 
 /**

--- a/opendps/opendps.c
+++ b/opendps/opendps.c
@@ -319,7 +319,7 @@ set_param_status_t opendps_set_calibration(char *name, float *value)
     }
     
     if (!past_write_unit(&g_past, param, (void*) value, sizeof(*value))) {
-        dbg_printf("Error: past write app git hash failed!\n");
+        dbg_printf("Error: past write opendps set calibration failed!\n");
         return ps_flash_error;
     }
 

--- a/opendps/opendps.c
+++ b/opendps/opendps.c
@@ -303,13 +303,13 @@ set_param_status_t opendps_set_calibration(char *name, float *value)
     } else if(strcmp(name,"A_DAC_C")==0){
         param = past_A_DAC_C;
     } else if(strcmp(name,"V_ADC_K")==0){
-        param = past_V_DAC_K;
-    } else if(strcmp(name,"V_ADC_C")==0){
-        param = past_V_DAC_C;
-    } else if(strcmp(name,"V_DAC_K")==0){
         param = past_V_ADC_K;
-    } else if(strcmp(name,"V_DAC_C")==0){
+    } else if(strcmp(name,"V_ADC_C")==0){
         param = past_V_ADC_C;
+    } else if(strcmp(name,"V_DAC_K")==0){
+        param = past_V_DAC_K;
+    } else if(strcmp(name,"V_DAC_C")==0){
+        param = past_V_DAC_C;
     } else if(strcmp(name,"VIN_ADC_K")==0){
         param = past_VIN_ADC_K;
     } else if(strcmp(name,"VIN_ADC_C")==0){
@@ -348,6 +348,7 @@ bool opendps_clear_calibration(void)
 
     /** Re-init pwrctl as calibration coefs have now been cleared */
     pwrctl_init(&g_past);
+    uui_refresh(&func_ui, false);
     return true;
 }
 
@@ -843,8 +844,6 @@ static void event_handler(void)
 int main(int argc, char const *argv[])
 {
     hw_init();
-    pwrctl_init(&g_past); // Must be after DAC init
-    event_init();
 
 #ifdef CONFIG_COMMANDLINE
     dbg_printf("Welcome to OpenDPS!\n");
@@ -867,6 +866,8 @@ int main(int argc, char const *argv[])
         /** @todo Handle past init failure */
     }
 
+    pwrctl_init(&g_past); // Must be after DAC init and Past init
+    event_init();
     check_master_reset();
     read_past_settings();
     ui_init();

--- a/opendps/opendps.c
+++ b/opendps/opendps.c
@@ -774,7 +774,7 @@ static void event_handler(void)
 int main(int argc, char const *argv[])
 {
     hw_init();
-    pwrctl_init(); // Must be after DAC init
+    pwrctl_init(&g_past); // Must be after DAC init
     event_init();
 
 #ifdef CONFIG_COMMANDLINE

--- a/opendps/opendps.h
+++ b/opendps/opendps.h
@@ -103,6 +103,23 @@ bool opendps_get_curr_function_param_value(char *name, char *value, uint32_t val
 set_param_status_t opendps_set_parameter(char *name, char *value);
 
 /**
+ * @brief      Sets Calibration Data
+ *
+ * @param      name Name of calibration variable to set
+ * @value      value Value to set it to
+ *
+ * @return     Status of the operation
+ */
+set_param_status_t opendps_set_calibration(char *name, float *value);
+
+/**
+ * @brief      Clear Calibration Data
+ *
+ * @return     True on success
+ */
+bool opendps_clear_calibration(void);
+
+/**
  * @brief      Enable output of current function
  *
  * @param[in]  enable  Enable or disable

--- a/opendps/pastunits.h
+++ b/opendps/pastunits.h
@@ -34,6 +34,17 @@ typedef enum {
     /** stored as strings */
     past_boot_git_hash,
     past_app_git_hash,
+    /** stored as floats */
+    past_A_ADC_K,
+    past_A_ADC_C,
+    past_A_DAC_K,
+    past_A_DAC_C,
+    past_V_DAC_K,
+    past_V_DAC_C,
+    past_V_ADC_K,
+    past_V_ADC_C,
+    past_VIN_ADC_K,
+    past_VIN_ADC_C,
     /** A past unit who's precense indicates we have a non finished upgrade and
     must not boot */
     past_upgrade_started = 0xff

--- a/opendps/protocol.h
+++ b/opendps/protocol.h
@@ -55,6 +55,8 @@ typedef enum {
     cmd_temperature_report,
     cmd_version,
     cmd_cal_report,
+    cmd_set_calibration,
+    cmd_clear_calibration,
     cmd_response = 0x80
 } command_t;
 

--- a/opendps/pwrctl.h
+++ b/opendps/pwrctl.h
@@ -30,6 +30,16 @@
 #include "past.h"
 
 extern uint32_t pwrctl_i_limit_raw;
+extern float a_adc_k_coef;
+extern float a_adc_c_coef;
+extern float a_dac_k_coef;
+extern float a_dac_c_coef;
+extern float v_adc_k_coef;
+extern float v_adc_c_coef;
+extern float v_dac_k_coef;
+extern float v_dac_c_coef;
+extern float vin_adc_k_coef;
+extern float vin_adc_c_coef;
 
 /**
   * @brief Initialize the power control module

--- a/opendps/pwrctl.h
+++ b/opendps/pwrctl.h
@@ -27,6 +27,7 @@
 
 #include <stdint.h>
 #include <stdbool.h>
+#include "past.h"
 
 extern uint32_t pwrctl_i_limit_raw;
 
@@ -34,7 +35,7 @@ extern uint32_t pwrctl_i_limit_raw;
   * @brief Initialize the power control module
   * @retval none
   */
-void pwrctl_init(void);
+void pwrctl_init(past_t *past);
 
 /**
   * @brief Set voltage output

--- a/opendps/uui.h
+++ b/opendps/uui.h
@@ -96,6 +96,7 @@ typedef enum {
     ps_unknown_name,
     ps_range_error,
     ps_not_supported,
+    ps_flash_error,
 } set_param_status_t;
 
 /**


### PR DESCRIPTION
The goal of this is to allow each device to have it's calibration coefficients changed by the user through dpsctl and ultimately we will use what is here to devise a reliable calibration routine to finally sort out #17 

The changes/additions that have been made are as follows:

1. Calibration coefficients can now be stored in past. If they are not stored then the defaults from dps-model.h are used. This is so that down the line we can have non-volatile device specific calibration that does not require a device specific bin file which they currently do

2. The constants in dps-model.h have been changed from doubles to floats. This is done to simplify the maths done by pwrctl substantially as there isn't a floating point operation unit on the STM32F100. It also reduces the amount of space used by the coefficients in past as mentioned in 1)

3. You may now set a specific calibration coefficient like so:
```
% python dpsctl.py -c V_ADC_C=6.6
V_ADC_C: ok
```
You can also set multiple coefficients at once:
```
% python dpsctl.py -c V_ADC_C=6.6 V_ADC_K=7.7
V_ADC_C: ok
V_ADC_K: ok
```
Any set coefficient is non-volatile and will remain through power-cycles. This is very useful for people who have devices that are slightly off and need tweaking. It will also be very useful for determining ballpark figures for new devices such as the DPS8005 in #68.

4. You can restore the device to the defaults defined in dps-model.h by using:
`% python dpsctl.py --calibration_reset`

5. If you'd like to see what the coefficients are currently set to or what the ADC or DACs are set to, use the following from the [recent merge](https://github.com/kanflo/opendps/commit/a40123155cd5fd8c083bfc3b640ac20133ee4bee):
`% python dpsctl.py -cr`
