### PR TITLE
Fix TFT drawing offset

### DIFF
--- a/opendps/ili9163c.c
+++ b/opendps/ili9163c.c
@@ -255,20 +255,22 @@ void ili9163c_set_window(uint16_t x0, uint16_t y0, uint16_t x1, uint16_t y1)
 {
     write_command(CMD_CLMADRS); // Column
     if (rotation == 0 || rotation > 1) {
-        write_data16(x0);
-        write_data16(x1);
+        /** @todo: find out why the magic numbers 3 and 2 are needed for correct
+         *         drawing on the DPS TFTs */
+        write_data16(x0 + 3);
+        write_data16(x1 + 3);
     } else {
-        write_data16(x0 + __OFFSET);
-        write_data16(x1 + __OFFSET);
+        write_data16(x0 + 3);
+        write_data16(x1 + 3);
     }
 
     write_command(CMD_PGEADRS); // Page
     if (rotation == 0) {
-        write_data16(y0 + __OFFSET);
-        write_data16(y1 + __OFFSET);
+        write_data16(y0 + 2);
+        write_data16(y1 + 2);
     } else {
-        write_data16(y0);
-        write_data16(y1);
+        write_data16(y0 + 2);
+        write_data16(y1 + 2);
     }
     write_command(CMD_RAMWR); // Into RAM
 }

--- a/opendps/ili9163c.c
+++ b/opendps/ili9163c.c
@@ -255,8 +255,8 @@ void ili9163c_set_window(uint16_t x0, uint16_t y0, uint16_t x1, uint16_t y1)
 {
     write_command(CMD_CLMADRS); // Column
     if (rotation == 0 || rotation > 1) {
-        /** @todo: find out why the magic numbers 3 and 2 are needed for correct
-         *         drawing on the DPS TFTs */
+        /** @todo: find out why an offset is needed for correct drawing on the
+         *         DPS TFTs */
         write_data16(x0 + __CONST_X_OFFSET);
         write_data16(x1 + __CONST_X_OFFSET);
     } else {

--- a/opendps/ili9163c.c
+++ b/opendps/ili9163c.c
@@ -257,20 +257,20 @@ void ili9163c_set_window(uint16_t x0, uint16_t y0, uint16_t x1, uint16_t y1)
     if (rotation == 0 || rotation > 1) {
         /** @todo: find out why the magic numbers 3 and 2 are needed for correct
          *         drawing on the DPS TFTs */
-        write_data16(x0 + 3);
-        write_data16(x1 + 3);
+        write_data16(x0 + __CONST_X_OFFSET);
+        write_data16(x1 + __CONST_X_OFFSET);
     } else {
-        write_data16(x0 + 3);
-        write_data16(x1 + 3);
+        write_data16(x0 + __CONST_X_OFFSET);
+        write_data16(x1 + __CONST_X_OFFSET);
     }
 
     write_command(CMD_PGEADRS); // Page
     if (rotation == 0) {
-        write_data16(y0 + 2);
-        write_data16(y1 + 2);
+        write_data16(y0 + __CONST_Y_OFFSET);
+        write_data16(y1 + __CONST_Y_OFFSET);
     } else {
-        write_data16(y0 + 2);
-        write_data16(y1 + 2);
+        write_data16(y0 + __CONST_Y_OFFSET);
+        write_data16(y1 + __CONST_Y_OFFSET);
     }
     write_command(CMD_RAMWR); // Into RAM
 }

--- a/opendps/ili9163c.c
+++ b/opendps/ili9163c.c
@@ -254,23 +254,47 @@ void ili9163c_fill_rect(int16_t x, int16_t y, int16_t w, int16_t h, uint16_t col
 void ili9163c_set_window(uint16_t x0, uint16_t y0, uint16_t x1, uint16_t y1)
 {
     write_command(CMD_CLMADRS); // Column
-    if (rotation == 0 || rotation > 1) {
-        /** @todo: find out why an offset is needed for correct drawing on the
-         *         DPS TFTs */
-        write_data16(x0 + __CONST_X_OFFSET);
-        write_data16(x1 + __CONST_X_OFFSET);
-    } else {
-        write_data16(x0 + __CONST_X_OFFSET);
-        write_data16(x1 + __CONST_X_OFFSET);
+    if (rotation == 3)
+    {
+        write_data16(x0 + 3);
+        write_data16(x1 + 3);
+    }
+    else if (rotation == 2)
+    {
+        write_data16(x0 + 2);
+        write_data16(x1 + 2);
+    }
+    else if (rotation == 1)
+    {
+        write_data16(x0 + 1);
+        write_data16(x1 + 1);
+    }
+    else
+    {
+        write_data16(x0 + 2);
+        write_data16(x1 + 2);
     }
 
     write_command(CMD_PGEADRS); // Page
-    if (rotation == 0) {
-        write_data16(y0 + __CONST_Y_OFFSET);
-        write_data16(y1 + __CONST_Y_OFFSET);
-    } else {
-        write_data16(y0 + __CONST_Y_OFFSET);
-        write_data16(y1 + __CONST_Y_OFFSET);
+    if (rotation == 3)
+    {
+        write_data16(y0 + 2);
+        write_data16(y1 + 2);
+    }
+    else if (rotation == 2)
+    {
+        write_data16(y0 + 3);
+        write_data16(y1 + 3);
+    }
+    else if (rotation == 1)
+    {
+        write_data16(y0 + 2);
+        write_data16(y1 + 2);
+    }
+    else
+    {
+        write_data16(y0 + 1);
+        write_data16(y1 + 1);
     }
     write_command(CMD_RAMWR); // Into RAM
 }

--- a/opendps/ili9163c_settings.h
+++ b/opendps/ili9163c_settings.h
@@ -29,6 +29,8 @@ you can copy those parameters and create setup for different displays.
 	#define __COLORSPC		COLORSPACE// 1:GBR - 0:RGB
 	#define __GAMMASET3		//uncomment for another gamma
 	#define __OFFSET		32//*see note 2
+	#define __CONST_X_OFFSET 3
+	#define __CONST_Y_OFFSET 2
 	//Tested!
 #elif defined (__144_BLACK_PCB__)
 	#define _TFTWIDTH  		128//the REAL W resolution of the TFT

--- a/opendps/opendps.c
+++ b/opendps/opendps.c
@@ -396,6 +396,21 @@ static void main_ui_tick(void)
     (void) v_out_raw;
     input_voltage.value = pwrctl_calc_vin(v_in_raw);
     input_voltage.ui.draw(&input_voltage.ui);
+
+    uint32_t y_offset = 0;
+    uint32_t x_offset = 0;
+
+    for (uint32_t y = 0 + y_offset; y < 128 + y_offset; y++) {
+        ili9163c_draw_pixel(x_offset, y, YELLOW);
+//        ili9163c_draw_pixel(127, y, YELLOW); // No adding x_offset here :-/
+        ili9163c_draw_pixel(127 + x_offset, y, YELLOW); // Doesn't appear
+    }
+
+    for (uint32_t x = 0 + x_offset; x < 128 + x_offset; x++) {
+        ili9163c_draw_pixel(x, y_offset, YELLOW);
+//        ili9163c_draw_pixel(x, 127, YELLOW); // No adding y_offset here :-/
+        ili9163c_draw_pixel(x, 127 + y_offset, YELLOW); // Doesn't appear
+    }
 }
 
 /**

--- a/opendps/opendps.c
+++ b/opendps/opendps.c
@@ -396,21 +396,6 @@ static void main_ui_tick(void)
     (void) v_out_raw;
     input_voltage.value = pwrctl_calc_vin(v_in_raw);
     input_voltage.ui.draw(&input_voltage.ui);
-
-    uint32_t y_offset = 0;
-    uint32_t x_offset = 0;
-
-    for (uint32_t y = 0 + y_offset; y < 128 + y_offset; y++) {
-        ili9163c_draw_pixel(x_offset, y, YELLOW);
-//        ili9163c_draw_pixel(127, y, YELLOW); // No adding x_offset here :-/
-        ili9163c_draw_pixel(127 + x_offset, y, YELLOW); // Doesn't appear
-    }
-
-    for (uint32_t x = 0 + x_offset; x < 128 + x_offset; x++) {
-        ili9163c_draw_pixel(x, y_offset, YELLOW);
-//        ili9163c_draw_pixel(x, 127, YELLOW); // No adding y_offset here :-/
-        ili9163c_draw_pixel(x, 127 + y_offset, YELLOW); // Doesn't appear
-    }
 }
 
 /**


### PR DESCRIPTION
While not a pretty patch, it solves the offset issue. At least until a proper data sheet for the module is found. I have so far only tested it on an ancient DPS5005, it needs testing on newer hardware.