### PR TITLE
Display brightness control

### DIFF
--- a/dpsctl/dpsctl.py
+++ b/dpsctl/dpsctl.py
@@ -55,7 +55,7 @@ if calibration_debug_plotting:
 import protocol
 import uframe
 from protocol import (create_cmd, create_enable_output, create_lock, create_set_calibration,
-                      create_set_function, create_set_parameter, create_temperature,
+                      create_set_function, create_set_parameter, create_temperature, create_set_brightness,
                       create_upgrade_data, create_upgrade_start, create_change_screen,
                       unpack_cal_report, unpack_query_response, unpack_version_response)
 from uhej import uhej
@@ -394,6 +394,8 @@ def handle_response(command, frame, args, quiet=False):
         pass
     elif resp_command == protocol.CMD_CHANGE_SCREEN:
         pass
+    elif resp_command == protocol.CMD_SET_BRIGHTNESS:
+        pass
     else:
         print("Unknown response {:d} from device.".format(resp_command))
 
@@ -525,6 +527,13 @@ def handle_commands(args):
 
     if args.calibrate:
         do_calibration(comms, args)
+
+    if args.brightness:
+        if args.brightness >=0 and args.brightness <=100:
+            communicate(comms, create_set_brightness(args.brightness), args)
+        else:
+            fail("brightness must be between 0 and 100")
+
 
 
 def is_ip_address(if_name):
@@ -1101,6 +1110,7 @@ def main():
 
     parser.add_argument('-d', '--device', help="OpenDPS device to connect to. Can be a /dev/tty device or an IP number. If omitted, dpsctl.py will try the environment variable DPSIF", default='')
     parser.add_argument('-b', '--baudrate', type=int, dest="baudrate", help="Set baudrate used for serial communications", default=115200)
+    parser.add_argument('-B', '--brightness', type=int, help="Set display brightness (0..100)")
     parser.add_argument('-S', '--scan', action="store_true", help="Scan for OpenDPS wifi devices")
     parser.add_argument('-f', '--function', nargs='?', help="Set active function")
     parser.add_argument('-F', '--list-functions', action='store_true', help="List available functions")

--- a/dpsctl/protocol.py
+++ b/dpsctl/protocol.py
@@ -49,6 +49,7 @@ CMD_CAL_REPORT = 18
 CMD_SET_CALIBRATION = 19
 CMD_CLEAR_CALIBRATION = 20
 CMD_CHANGE_SCREEN = 21
+CMD_SET_BRIGHTNESS = 22
 CMD_RESPONSE = 0x80
 
 # wifi_status_t
@@ -207,6 +208,14 @@ def create_change_screen(screen):
     f = uFrame()
     f.pack8(CMD_CHANGE_SCREEN)
     f.pack8(screen)
+    f.end()
+    return f
+
+
+def create_set_brightness(brightness):
+    f = uFrame()
+    f.pack8(CMD_SET_BRIGHTNESS)
+    f.pack8(brightness)
     f.end()
     return f
 

--- a/opendps/hw.c
+++ b/opendps/hw.c
@@ -185,7 +185,7 @@ void hw_set_current_dac(uint16_t i_dac)
   * @brief Initialize TIM4 that drives the backlight of the TFT
   * @retval None
   */
-void hw_enable_backlight(void)
+void hw_enable_backlight(uint8_t brightness)
 {
     rcc_periph_clock_enable(RCC_TIM4);
     TIM4_CNT = 1;
@@ -193,10 +193,29 @@ void hw_enable_backlight(void)
     TIM4_CCER = 0x10;
     TIM4_CCMR1 = 0x6800;
     TIM4_ARR = 0x8bdf;
-    TIM4_CCR2 = 0x5dc0;
+    //TIM4_CCR2 = 0x5dc0;
+    // no brightness increase above 0x7FFF, so 1% would be 0x147
+    TIM4_CCR2 = brightness * 0x147;
     TIM4_DMAR = 0x81;
     // Set auto reload, start timer.
     TIM4_CR1 |= TIM_CR1_ARPE | TIM_CR1_CEN;
+}
+/**
+  * @brief Set TFT backlight value
+  * @retval None
+  */
+void hw_set_backlight(uint8_t brightness)
+{
+    TIM4_CCR2 = brightness * 0x147;
+}
+
+/**
+  * @brief Get TFT backlight value
+  * @retval Brightness percentage
+  */
+uint8_t hw_get_backlight(void)
+{
+    return TIM4_CCR2 / 0x147;
 }
 
 /**

--- a/opendps/hw.h
+++ b/opendps/hw.h
@@ -107,7 +107,19 @@ void hw_set_current_dac(uint16_t i_dac);
   * @brief Initialize TIM4 that drives the backlight of the TFT
   * @retval None
   */
-void hw_enable_backlight(void);
+void hw_enable_backlight(uint8_t brighness);
+
+/**
+  * @brief Set TFT backlight value
+  * @retval None
+  */
+void hw_set_backlight(uint8_t brightness);
+
+/**
+  * @brief Get TFT backlight value
+  * @retval Brightness percentage
+  */
+uint8_t hw_get_backlight(void);
 
 /**
   * @brief Get the ADC value that triggered the OCP

--- a/opendps/pastunits.h
+++ b/opendps/pastunits.h
@@ -45,6 +45,7 @@ typedef enum {
     past_V_ADC_C,
     past_VIN_ADC_K,
     past_VIN_ADC_C,
+    past_tft_brightness,
     /** A past unit who's precense indicates we have a non finished upgrade and
     must not boot */
     past_upgrade_started = 0xff

--- a/opendps/protocol.h
+++ b/opendps/protocol.h
@@ -58,6 +58,7 @@ typedef enum {
     cmd_set_calibration,
     cmd_clear_calibration,
     cmd_change_screen,
+    cmd_set_brightness,
     cmd_response = 0x80
 } command_t;
 

--- a/opendps/protocol_handler.c
+++ b/opendps/protocol_handler.c
@@ -309,6 +309,20 @@ static command_status_t handle_enable_output(uint8_t *payload, uint32_t payload_
     }
 }
 
+static command_status_t handle_set_brightness(uint8_t *payload, uint32_t payload_len)
+{
+    emu_printf("%s\n", __FUNCTION__);
+    uint8_t cmd;
+    uint8_t brightness_pct;
+    DECLARE_UNPACK(payload, payload_len);
+    UNPACK8(cmd);
+    (void) cmd;
+    UNPACK8(brightness_pct);
+    hw_set_backlight(brightness_pct);
+    return cmd_success;
+}
+
+
 static command_status_t handle_temperature(uint8_t *payload, uint32_t payload_len)
 {
     emu_printf("%s\n", __FUNCTION__);
@@ -540,6 +554,9 @@ static void handle_frame(uint8_t *frame, uint32_t length)
                 break;
             case cmd_change_screen:
                 success = handle_change_screen(payload, payload_len);
+                break;
+            case cmd_set_brightness:
+                success = handle_set_brightness(payload, payload_len);
                 break;
             default:
                 emu_printf("Got unknown command %d (0x%02x)\n", cmd, cmd);


### PR DESCRIPTION
Currently only dpsctl allows to set brightness level (-B <percentage>), can't decide which knob combination would be best to attach this feature;)
Value is stored in past. Quite blithely, as I "stole" another 32bits due to "Friday the 13th of April" bug, but it might be good idea to merge past_tft_inversion and past_tft_brightness into one display-config record.