### PR TITLE
Force Vin_ADC, Vout_ADC and Vout_DAC through the 0,0 point

### DIFF
--- a/dpsctl/dpsctl.py
+++ b/dpsctl/dpsctl.py
@@ -632,10 +632,6 @@ def best_fit_through_origin(X, Y):
     """
     Calculate linear line of best fit coefficients passing through (0,0) (y = kx + 0)
     """
-    xbar = sum(X)/len(X)
-    ybar = sum(Y)/len(Y)
-    n = len(X)  # or len(Y)
-    
     x = np.array(X)
     y = np.array(Y)
     

--- a/dpsctl/dpsctl.py
+++ b/dpsctl/dpsctl.py
@@ -47,7 +47,7 @@ import sys
 import threading
 import time
 import math
-import numpy
+import numpy as np
 
 calibration_debug_plotting = False  # Change this to True to enable plotting of the calibration graphs during dpsctl -C
 if calibration_debug_plotting:

--- a/dpsctl/dpsctl.py
+++ b/dpsctl/dpsctl.py
@@ -639,6 +639,8 @@ def best_fit_through_origin(X, Y):
 
     k, _, _, _ = np.linalg.lstsq(x, y, rcond=None)
 
+    k = k.tolist()[0] # Convert numpy array back to a float
+
     return k, 0
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 pycrc==1.21
 pyserial==3.4
+numpy>=1.13.0


### PR DESCRIPTION
This is to resolve #158 

This is completely untested and unfortunately adds a requirement to have numpy installed. I'd rather not risk getting the maths wrong