### PR TITLE
cc/cv/cl screens do not clear properly

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ jobs:
       script:
         - mkdir output
         - chmod 777 output
-        - docker run -t -u opendps -v $(readlink -f .):/parent:ro -v $(readlink -f .)/output:/output opendps /parent/docker/build.sh
+        - docker run --rm -t -u opendps -v $(readlink -f .):/parent:ro -v $(readlink -f .)/output:/output opendps /parent/docker/build.sh
       
       deploy:
         provider: releases

--- a/build_binaries.sh
+++ b/build_binaries.sh
@@ -14,4 +14,4 @@ docker build -t opendps_$PROJECT docker
 mkdir -p output
 chmod 777 output
 
-docker run -t -u opendps -v $(readlink -f .):/parent:ro -v $(readlink -f .)/output:/output opendps_$PROJECT /parent/docker/build.sh "$@"
+docker run --rm -t -u opendps -v $(readlink -f .):/parent:ro -v $(readlink -f .)/output:/output opendps_$PROJECT /parent/docker/build.sh "$@"

--- a/opendps/func_cc.c
+++ b/opendps/func_cc.c
@@ -119,7 +119,7 @@ ui_screen_t cc_screen = {
     .icon_width = GFX_CC_WIDTH,
     .icon_height = GFX_CC_HEIGHT,
     .activated = NULL,
-    .deactivated = NULL,
+    .deactivated = &deactivated,
     .enable = &cc_enable,
     .past_save = &past_save,
     .past_restore = &past_restore,
@@ -247,6 +247,15 @@ static void current_changed(ui_number_t *item)
     saved_i = item->value;
     (void) pwrctl_set_iout(item->value);
 }
+
+/**
+ * @brief      Do any required clean up before changing away from this screen
+ */
+static void deactivated(void)
+{
+    tft_clear();
+}
+
 
 /**
  * @brief      Save persistent parameters

--- a/opendps/func_cc.c
+++ b/opendps/func_cc.c
@@ -50,6 +50,7 @@ static void cc_enable(bool _enable);
 static void voltage_changed(ui_number_t *item);
 static void current_changed(ui_number_t *item);
 static void cc_tick(void);
+static void deactivated(void);
 static void past_save(past_t *past);
 static void past_restore(past_t *past);
 static set_param_status_t set_parameter(char *name, char *value);

--- a/opendps/func_cl.c
+++ b/opendps/func_cl.c
@@ -277,6 +277,8 @@ static void deactivated(void)
         tft_fill(XPOS_CCCV, 128 - GFX_CC_HEIGHT, GFX_CC_WIDTH, GFX_CC_HEIGHT, BLACK);
     }
     current_mode_gfx = CUR_GFX_NOT_DRAWN;
+
+    tft_clear();
 }
 
 /**

--- a/opendps/func_cv.c
+++ b/opendps/func_cv.c
@@ -117,7 +117,7 @@ ui_screen_t cv_screen = {
     .icon_width = GFX_CV_WIDTH,
     .icon_height = GFX_CV_HEIGHT,
     .activated = NULL,
-    .deactivated = NULL,
+    .deactivated = &deactivated,
     .enable = &cv_enable,
     .past_save = &past_save,
     .past_restore = &past_restore,
@@ -245,6 +245,14 @@ static void current_changed(ui_number_t *item)
 {
     saved_i = item->value;
     (void) pwrctl_set_ilimit(item->value);
+}
+
+/**
+ * @brief      Do any required clean up before changing away from this screen
+ */
+static void deactivated(void)
+{
+    tft_clear();
 }
 
 /**

--- a/opendps/func_cv.c
+++ b/opendps/func_cv.c
@@ -48,6 +48,7 @@ static void cv_enable(bool _enable);
 static void voltage_changed(ui_number_t *item);
 static void current_changed(ui_number_t *item);
 static void cv_tick(void);
+static void deactivated(void);
 static void past_save(past_t *past);
 static void past_restore(past_t *past);
 static set_param_status_t set_parameter(char *name, char *value);


### PR DESCRIPTION
As I was testing adding new screens to the project, it looks like that  the cc/cv/cl screens don't properly clear on deactivation which might cause artifacts to be shown on the next screen.

Added a tft_clear() call on deactivation.