### PR TITLE
Make func_cv optional

### DIFF
--- a/opendps/Makefile
+++ b/opendps/Makefile
@@ -44,7 +44,10 @@ COLOR_INPUT ?= WHITE
 TINT ?= ffffff
 
 # Enable CC mode
-CC_ENABLE ?= 1
+CC_ENABLE ?= 0
+
+# Enable CV mode
+CV_ENABLE ?= 0
 
 # Enable cl mode
 CL_ENABLE ?= 1
@@ -115,6 +118,11 @@ endif
 ifeq ($(CC_ENABLE),1)
 	CFLAGS +=-DCONFIG_CC_ENABLE
 	OBJS += func_cc.o
+endif
+
+ifeq ($(CV_ENABLE),1)
+	CFLAGS +=-DCONFIG_CV_ENABLE
+	OBJS += func_cv.o
 endif
 
 ifeq ($(CL_ENABLE),1)

--- a/opendps/opendps.c
+++ b/opendps/opendps.c
@@ -54,9 +54,11 @@
 #include "uui.h"
 #include "uui_number.h"
 #include "opendps.h"
-#include "func_cv.h"
 #include "settings_calibration.h"
 #include "my_assert.h"
+#ifdef CONFIG_CV_ENABLE
+#include "func_cv.h"
+#endif // CONFIG_CV_ENABLE
 #ifdef CONFIG_CC_ENABLE
 #include "func_cc.h"
 #endif // CONFIG_CC_ENABLE
@@ -430,7 +432,9 @@ static void ui_init(void)
 
     /** Initialise the function screens */
     uui_init(&func_ui, &g_past);
+#ifdef CONFIG_CV_ENABLE
     func_cv_init(&func_ui);
+#endif // CONFIG_CV_ENABLE
 #ifdef CONFIG_CC_ENABLE
     func_cc_init(&func_ui);
 #endif // CONFIG_CC_ENABLE


### PR DESCRIPTION
The func_cv screen was not optional despite the fact that func_cl is the combined version of func_cc and func_cv. The Makefile now supports the CV_ENABLE flag to toggle this screen.

Because cl combines features in cc and cv, both cc and cv are now disabled by default in favor for the cl screen.