### PR TITLE
Function generator should not clear on activation to prevent glitchiness

### DIFF
--- a/opendps/func_gen.c
+++ b/opendps/func_gen.c
@@ -463,11 +463,6 @@ static void func_changed(ui_icon_t *item)
  */
 static void activated(void)
 {
-    /** The screen is different here, let's clear it */
-    tft_clear();
-    for (uint32_t i = 0; i < gen_screen.num_items; i++) {
-        gen_screen.items[i]->draw(gen_screen.items[i]);
-    }
     tft_puts(FONT_FULL_SMALL, "Vout:", 6, 15+FONT_FULL_SMALL_MAX_GLYPH_HEIGHT, 64, 20, WHITE, false);
     tft_puts(FONT_FULL_SMALL, "Freq:", 6, 42+FONT_FULL_SMALL_MAX_GLYPH_HEIGHT, 64, 20, WHITE, false);
     tft_puts(FONT_FULL_SMALL, "Func:", 6, 69+FONT_FULL_SMALL_MAX_GLYPH_HEIGHT, 64, 20, WHITE, false);


### PR DESCRIPTION
When switching to the function generator screen, the UI elements flash about 3 times.

Applying #165 will make the screen blank on deactivation. This means that the code in the activation function to clear the screen in the function generator module is redundant and no longer required. Without these extra calls to clear and redraw UI elements, the glitchiness goes away as well.


