### PR TITLE
Change default build to O2

### DIFF
--- a/opendps/Makefile
+++ b/opendps/Makefile
@@ -53,7 +53,7 @@ CL_ENABLE ?= 1
 FUNCGEN_ENABLE ?= 1
 
 GIT_VERSION := $(shell git describe --abbrev=4 --dirty --always --tags)
-CFLAGS = -I. -DGIT_VERSION=\"$(GIT_VERSION)\" -Wno-missing-braces
+CFLAGS = -I. -DGIT_VERSION=\"$(GIT_VERSION)\" -Wno-missing-braces -O2
 
 # Output voltage and current limit are persisted in flash,
 # this is the default setting


### PR DESCRIPTION
This works for me and it makes the UI feel a little snappier (could be placebo, not sure if the UI is firmware or screen hardware limited). 

If I have a large number of local changes or custom images I find the firmware won't fit in memory with O3. I've made it O2 for now to save any future headaches from new features.