### PR TITLE
Add a GCC warning for variable length arrays

### DIFF
--- a/libopencm3.rules.mk
+++ b/libopencm3.rules.mk
@@ -96,7 +96,7 @@ SCRIPT_DIR	= $(OPENCM3_DIR)/scripts
 
 TGT_CFLAGS	+= $(OPT) $(CSTD) -g
 TGT_CFLAGS	+= $(ARCH_FLAGS)
-TGT_CFLAGS	+= -Wextra -Wshadow -Wimplicit-function-declaration
+TGT_CFLAGS	+= -Wextra -Wshadow -Wimplicit-function-declaration -Wvla
 TGT_CFLAGS	+= -Wredundant-decls -Wmissing-prototypes -Wstrict-prototypes
 TGT_CFLAGS	+= -fno-common -ffunction-sections -fdata-sections
 


### PR DESCRIPTION
As referenced in #174