### PR TITLE
DPS5020 UI support (currents above 9.99A)

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 #### Give your DPS5005 the upgrade it deserves
 
-OpenDPS is a FOSS firmware replacement for the DPS5005 (and DPS3003, DPS3005, DPS5015, DP50V5A and possibly others) that has the same functionality, has a less cluttered user interface and is remote controllable via wifi (ESP8266) or via a serial port.
+OpenDPS is a FOSS firmware replacement for the DPS5005 (and DPS3003, DPS3005, DPS5015, DP50V5A, DPS5020 and possibly others) that has the same functionality, has a less cluttered user interface and is remote controllable via wifi (ESP8266) or via a serial port.
 
 <p align="center">
 <img src="https://raw.githubusercontent.com/kanflo/opendps/master/image.jpg" alt="A DPS5005 with wifi"/>
@@ -176,7 +176,7 @@ The project consists of four parts:
 
 ### What about other DPS:es?
 
-OpenDPS has been verified to work with other models in the DPSx0xx series, such as the DPS3003, DPS3005 and DPS5015. The maxium settable output current can be defined when building opendps, see the makefile. Plese note that the hardware design might change at any time without any notice (I am not affiliated with its designer). This will render OpenDPS unusable until fixed.
+OpenDPS has been verified to work with other models in the DPSx0xx series, such as the DPS3003, DPS3005, DPS5015 and DPS5020. The maxium settable output current can be defined when building opendps, see the makefile. Plese note that the hardware design might change at any time without any notice (I am not affiliated with its designer). This will render OpenDPS unusable until fixed.
 
 ---
 Licensed under the MIT license. Have fun!

--- a/opendps/dps-model.h
+++ b/opendps/dps-model.h
@@ -42,7 +42,23 @@
  * */
 
 /** Contribution by @cleverfox */
-#if defined(DPS5015)
+#if defined(DPS5020)
+ #ifndef CONFIG_DPS_MAX_CURRENT
+  #define CONFIG_DPS_MAX_CURRENT (20000) // Please note that the UI currently does not handle settings larger that 9.99A
+ #endif
+ #define ADC_CHA_IOUT_GOLDEN_VALUE  (59)
+ #define A_ADC_K (float)6.75449f
+ #define A_ADC_C (float)-358.73f
+ #define A_DAC_K (float)0.16587f
+ #define A_DAC_C (float)243.793f
+ #define V_ADC_K (float)13.2930f
+ #define V_ADC_C (float)-179.91f
+ #define V_DAC_K (float)0.07528f
+ #define V_DAC_C (float)6.68949f
+
+ #define VIN_ADC_K (float)16.956f
+ #define VIN_ADC_C (float)6.6895f
+#elif defined(DPS5015)
  #ifndef CONFIG_DPS_MAX_CURRENT
   #define CONFIG_DPS_MAX_CURRENT (15000) // Please note that the UI currently does not handle settings larger that 9.99A
  #endif
@@ -99,8 +115,13 @@
 #endif // MODEL
 
 /** These are constant across all models currently but may require tuning for each model */
-#define VIN_ADC_K (float)16.746f
-#define VIN_ADC_C (float)64.112f
+#ifndef VIN_ADC_K
+ #define VIN_ADC_K (float)16.746f
+#endif
+
+#ifndef VIN_ADC_C
+ #define VIN_ADC_C (float)64.112f
+#endif
 
 #define VIN_VOUT_RATIO (float)1.1f /** (Vin / VIN_VOUT_RATIO) = Max Vout */
 

--- a/opendps/dps-model.h
+++ b/opendps/dps-model.h
@@ -46,6 +46,8 @@
  #ifndef CONFIG_DPS_MAX_CURRENT
   #define CONFIG_DPS_MAX_CURRENT (20000) // Please note that the UI currently does not handle settings larger that 9.99A
  #endif
+ #define CURRENT_DIGITS 2
+ #define CURRENT_DECIMALS 2
  #define ADC_CHA_IOUT_GOLDEN_VALUE  (59)
  #define A_ADC_K (float)6.75449f
  #define A_ADC_C (float)-358.73f

--- a/opendps/dps-model.h
+++ b/opendps/dps-model.h
@@ -60,8 +60,10 @@
  #define VIN_ADC_C (float)6.6895f
 #elif defined(DPS5015)
  #ifndef CONFIG_DPS_MAX_CURRENT
-  #define CONFIG_DPS_MAX_CURRENT (15000) // Please note that the UI currently does not handle settings larger that 9.99A
+  #define CONFIG_DPS_MAX_CURRENT (15000)
  #endif
+ #define CURRENT_DIGITS 2
+ #define CURRENT_DECIMALS 2
  #define ADC_CHA_IOUT_GOLDEN_VALUE  (59)
  #define A_ADC_K (float)6.8403f
  #define A_ADC_C (float)-394.06f
@@ -75,6 +77,8 @@
  #ifndef CONFIG_DPS_MAX_CURRENT
   #define CONFIG_DPS_MAX_CURRENT (5000)
  #endif
+ #define CURRENT_DIGITS 1
+ #define CURRENT_DECIMALS 3
  #define ADC_CHA_IOUT_GOLDEN_VALUE  (0x45)
  #define A_ADC_K (float)1.713f
  #define A_ADC_C (float)-118.51f
@@ -88,6 +92,8 @@
  #ifndef CONFIG_DPS_MAX_CURRENT
   #define CONFIG_DPS_MAX_CURRENT (5000)
  #endif
+ #define CURRENT_DIGITS 1
+ #define CURRENT_DECIMALS 3
  #define ADC_CHA_IOUT_GOLDEN_VALUE  (0x45)
  #define A_DAC_K (float)0.6402f
  #define A_DAC_C (float)299.5518f
@@ -101,6 +107,8 @@
  #ifndef CONFIG_DPS_MAX_CURRENT
   #define CONFIG_DPS_MAX_CURRENT (5000)
  #endif
+ #define CURRENT_DIGITS 1
+ #define CURRENT_DECIMALS 3
  #define ADC_CHA_IOUT_GOLDEN_VALUE  (0x00)
  #define A_ADC_K (float)1.751f
  #define A_ADC_C (float)-1.101f

--- a/opendps/func_cc.c
+++ b/opendps/func_cc.c
@@ -104,8 +104,8 @@ ui_number_t cc_current = {
     .min = 0,
     .max = CONFIG_DPS_MAX_CURRENT,
     .si_prefix = si_milli,
-    .num_digits = 1,
-    .num_decimals = 3,
+    .num_digits = CURRENT_DIGITS,
+    .num_decimals = CURRENT_DECIMALS,
     .unit = unit_ampere,
     .changed = &current_changed,
 };

--- a/opendps/func_cl.c
+++ b/opendps/func_cl.c
@@ -112,8 +112,8 @@ ui_number_t cl_current = {
     .min = 0,
     .max = CONFIG_DPS_MAX_CURRENT,
     .si_prefix = si_milli,
-    .num_digits = 1,
-    .num_decimals = 3,
+    .num_digits = CURRENT_DIGITS,
+    .num_decimals = CURRENT_DECIMALS,
     .unit = unit_ampere,
     .changed = &current_changed,
 };

--- a/opendps/func_cv.c
+++ b/opendps/func_cv.c
@@ -102,8 +102,8 @@ ui_number_t cv_current = {
     .min = 0,
     .max = CONFIG_DPS_MAX_CURRENT,
     .si_prefix = si_milli,
-    .num_digits = 1,
-    .num_decimals = 3,
+    .num_digits = CURRENT_DIGITS,
+    .num_decimals = CURRENT_DECIMALS,
     .unit = unit_ampere,
     .changed = &current_changed,
 };

--- a/opendps/hw.c
+++ b/opendps/hw.c
@@ -639,7 +639,7 @@ static void gpio_init(void)
 
     // PC13 I 0 Flt
 //    gpio_set_mode(GPIOC, GPIO_MODE_INPUT, GPIO_CNF_INPUT_FLOAT, GPIO13);
-#ifdef DPS5015
+#if defined(DPS5015) || defined(DPS5020)
 	gpio_set_mode(GPIOC, GPIO_MODE_OUTPUT_50_MHZ, GPIO_CNF_OUTPUT_PUSHPULL, GPIO13);
 #endif
 

--- a/opendps/pwrctl.c
+++ b/opendps/pwrctl.c
@@ -204,7 +204,7 @@ void pwrctl_enable_vout(bool enable)
     if (v_out_enabled) {
       (void) pwrctl_set_vout(v_out);
       (void) pwrctl_set_iout(i_out);
-#ifdef DPS5015
+#if defined(DPS5015) || defined(DPS5020)
         //gpio_clear(GPIOA, GPIO9); // this is power control on '5015
         gpio_set(GPIOB, GPIO11);    // B11 is fan control on '5015
         gpio_clear(GPIOC, GPIO13);  // C13 is power control on '5015
@@ -212,7 +212,7 @@ void pwrctl_enable_vout(bool enable)
         gpio_clear(GPIOB, GPIO11);  // B11 is power control on '5005
 #endif
     } else {
-#ifdef DPS5015
+#if defined(DPS5015) || defined(DPS5020)
         //gpio_set(GPIOA, GPIO9);    // gpio_set(GPIOB, GPIO11);
         gpio_clear(GPIOB, GPIO11); // B11 is fan control on '5015
         gpio_set(GPIOC, GPIO13);   // C13 is power control on '5015


### PR DESCRIPTION
Adds support for current display of over 9.99A on DPS5020. Is based off and therefore relies on the following PRs to first be merged:

https://github.com/kanflo/opendps/pull/200 DPS5020 support 
https://github.com/kanflo/opendps/pull/189 DPS5015 UI support
