### PR TITLE
Fixed LCD freeze for DPS5015

### DIFF
--- a/opendps/hw.c
+++ b/opendps/hw.c
@@ -518,8 +518,14 @@ static void gpio_init(void)
     // PA7  I 0 An                    ADC1_IN7        R30-U2.7:V_OUT-B
 //tft    gpio_set_mode(GPIOA, GPIO_MODE_INPUT, GPIO_CNF_INPUT_ANALOG, GPIO7);
 
-    // PA8  O 0 PP     (50 Mhz)       TFT.7           (not used by TFT)
+// PA8  O 0 PP     (50 Mhz)       TFT.7           (not used by TFT)
+#ifdef TFT_CSN_PORT
+    gpio_set_mode(TFT_CSN_PORT, GPIO_MODE_OUTPUT_50_MHZ, GPIO_CNF_OUTPUT_PUSHPULL, TFT_CSN_PIN);
+    gpio_set(TFT_CSN_PORT, TFT_CSN_PIN);
+#else
+    
     gpio_set_mode(GPIOA, GPIO_MODE_OUTPUT_50_MHZ, GPIO_CNF_OUTPUT_PUSHPULL, GPIO8);
+#endif
 //    gpio_clear(GPIOA, GPIO8); /** @todo DPS5005 comms version with fw 1.3 does this, check functions */
 
     // PA9  I 1 Flt

--- a/opendps/hw.h
+++ b/opendps/hw.h
@@ -24,6 +24,7 @@
 
 #ifndef __HW_H__
 #define __HW_H__
+#include "dps-model.h"
 
 /** We can provide max 800mV below Vin */
 #define V_IO_DELTA (800)
@@ -36,6 +37,10 @@
 #define TFT_RST_PIN  GPIO12
 #define TFT_A0_PORT  GPIOB
 #define TFT_A0_PIN   GPIO14
+#ifdef DPS5015 
+#define TFT_CSN_PORT GPIOA
+#define TFT_CSN_PIN  GPIO8
+#endif
 
 #define BUTTON_SEL_PORT GPIOA
 #define BUTTON_SEL_PIN  GPIO2

--- a/opendps/spi_driver.c
+++ b/opendps/spi_driver.c
@@ -29,6 +29,7 @@
 #include <spi.h>
 #include <errno.h>
 #include "spi_driver.h"
+#include "hw.h"
 
 /** Used to keep track of the SPI DMA status */
 typedef enum {
@@ -88,6 +89,10 @@ bool spi_dma_transceive(uint8_t *tx_buf, uint32_t tx_len, uint8_t *rx_buf, uint3
         temp = SPI_DR(SPI2);
     }
 
+#ifdef TFT_CSN_PORT
+    gpio_clear(TFT_CSN_PORT, TFT_CSN_PIN);
+#endif
+
     dma_status = spi_idle;
 
     if (rx_len) {
@@ -135,6 +140,10 @@ bool spi_dma_transceive(uint8_t *tx_buf, uint32_t tx_len, uint8_t *rx_buf, uint3
     while (dma_status != spi_idle) ;
     while (!(SPI_SR(SPI2) & SPI_SR_TXE)) ;
     while (SPI_SR(SPI2) & SPI_SR_BSY) ;
+
+#ifdef TFT_CSN_PORT
+    gpio_set(TFT_CSN_PORT, TFT_CSN_PIN);
+#endif
 
 #ifndef SPI_NSS_GROUNDED
     gpio_set(GPIOB, GPIO12);


### PR DESCRIPTION
Random freeze fix for DPS5015, if screen goes white, or freeze when you touch red multimeter probe to the GND DPS5015 connector, all credits goes to cleverfox, commit a88926c
Related to #50, and probably #10 .