### PR TITLE
Fix PyCRC installation

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-git+https://github.com/alexbutirskiy/PyCRC==1.21
+git+https://github.com/alexbutirskiy/PyCRC
 pyserial==3.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-pycrc==1.21
+git+https://github.com/alexbutirskiy/PyCRC==1.21
 pyserial==3.4


### PR DESCRIPTION
The PyCRC on PyPI is incompatible with this project. I found some old clone on GitHub (mirror or fork?) providing the right version, 1.21.