### PR TITLE
Added DPS3003 default parameters and fixed overflow in pwrctl_calc

### DIFF
--- a/opendps/dps-model.h
+++ b/opendps/dps-model.h
@@ -120,6 +120,23 @@
  #define V_DAC_C (float)2.2857f
  #define V_ADC_K (float)13.131f
  #define V_ADC_C (float)-111.9f
+#elif defined(DPS3003)
+ #ifndef CONFIG_DPS_MAX_CURRENT
+  #define CONFIG_DPS_MAX_CURRENT (3000)
+ #endif
+ #define CURRENT_DIGITS 1
+ #define CURRENT_DECIMALS 3
+ #define ADC_CHA_IOUT_GOLDEN_VALUE  (0x00)
+ #define A_ADC_K (float)0.99676f
+ #define A_ADC_C (float)-44.3156f
+ #define A_DAC_K (float)1.12507f
+ #define A_DAC_C (float)256.302f
+ #define V_DAC_K (float)0.12237f
+ #define V_DAC_C (float)10.1922f
+ #define V_ADC_K (float)8.16837f
+ #define V_ADC_C (float)-115.582f
+ #define VIN_ADC_K (float)16.7897f
+ #define VIN_ADC_C (float)16.6448f
 #else
  #error "Please set MODEL to the device you want to build for"
 #endif // MODEL

--- a/opendps/pwrctl.c
+++ b/opendps/pwrctl.c
@@ -296,7 +296,7 @@ uint32_t pwrctl_calc_iout(uint16_t raw)
   * @param i_limit_ma selected I_limit
   * @retval expected raw ADC value
   */
-uint16_t pwrctl_calc_ilimit_adc(uint16_t i_limit_ma)
+uint32_t pwrctl_calc_ilimit_adc(uint16_t i_limit_ma)
 {
     float value = (i_limit_ma - a_adc_c_coef) / a_adc_k_coef + 1;
     if (value <= 0)
@@ -310,7 +310,7 @@ uint16_t pwrctl_calc_ilimit_adc(uint16_t i_limit_ma)
   * @param v_limit_mv selected V_limit
   * @retval expected raw ADC value
   */
-uint16_t pwrctl_calc_vlimit_adc(uint16_t v_limit_mv)
+uint32_t pwrctl_calc_vlimit_adc(uint16_t v_limit_mv)
 {
     float value = (v_limit_mv - v_adc_c_coef) / v_adc_k_coef + 1;
     if (value <= 0)

--- a/opendps/pwrctl.h
+++ b/opendps/pwrctl.h
@@ -146,14 +146,14 @@ uint32_t pwrctl_calc_iout(uint16_t raw);
   * @param i_limit_ma selected I_limit
   * @retval expected raw ADC value
   */
-uint16_t pwrctl_calc_ilimit_adc(uint16_t i_limit_ma);
+uint32_t pwrctl_calc_ilimit_adc(uint16_t i_limit_ma);
 
 /**
   * @brief Calculate expected raw ADC value based on selected V_limit
   * @param v_limit_mv selected V_limit
   * @retval expected raw ADC value
   */
-uint16_t pwrctl_calc_vlimit_adc(uint16_t v_limit_mv);
+uint32_t pwrctl_calc_vlimit_adc(uint16_t v_limit_mv);
 
 /**
   * @brief Calculate DAC setting for constant current mode


### PR DESCRIPTION
The calibration of DPS3003 often resulted in malfunctioning of
CC and CL function due to a bug in pwrctl.c:pwrctl_calc_ilimit_adc:
The float value in pwrctl_calc_ilimit_adc might result in overflow
during the casting to the return value of type uint16_t.
The return type is changed to uint32_t.