### PR TITLE
make docker build_binaries.sh macOS compatible

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ jobs:
       script:
         - mkdir output
         - chmod 777 output
-        - docker run --rm -t -u opendps -v $(readlink -f .):/parent:ro -v $(readlink -f .)/output:/output opendps /parent/docker/build.sh
+        - docker run --rm -t -u opendps -v $(realpath .):/parent:ro -v $(realpath .)/output:/output opendps /parent/docker/build.sh
       
       deploy:
         provider: releases

--- a/build_binaries.sh
+++ b/build_binaries.sh
@@ -14,4 +14,4 @@ docker build -t opendps_$PROJECT docker
 mkdir -p output
 chmod 777 output
 
-docker run --rm -t -u opendps -v $(readlink -f .):/parent:ro -v $(readlink -f .)/output:/output opendps_$PROJECT /parent/docker/build.sh "$@"
+docker run --rm -t -u opendps -v $(realpath .):/parent:ro -v $(realpath .)/output:/output opendps_$PROJECT /parent/docker/build.sh "$@"


### PR DESCRIPTION
On my macbook `build_binaries.sh` didn't work : 
```
readlink: illegal option -- f
usage: readlink [-n] [file ...]
```

Turns out that readlink is something slightly different here : 
```
STAT(1)                   BSD General Commands Manual                  STAT(1)

NAME
     readlink, stat -- display file status

[...]

     -f format
             Display information using the specified format.  See the FORMATS
             section for a description of valid formats.
```

However, regarding the `-f` flag that is used, the [readlink man page for linux](https://www.man7.org/linux/man-pages/man1/readlink.1.html) also mentions 

> realpath(1) is the preferred command to use for canonicalization functionality.

And that command also works on macOS :-)