### PR TITLE
Independent flashing of openocd and bootloader

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,8 +31,6 @@ make -C opendps flash
 make -C dpsboot flash
 ```
 
-*Please note that you currently MUST flash the bootloader last as OpenOCD overwrites the bootloader when flashing the firmware. Currently no idea why :-/ *
-
 Check [the blog](https://johan.kanflo.com/upgrading-your-dps5005/) for instructions on how to unlock and flash your DPS5005.
 
 Second, build and flash the ESP8266 firmware. First you need to create the file `esp8266-proxy/esp-open-rtos/include/private_ssid_config.h` with the following content:

--- a/libopencm3.rules.mk
+++ b/libopencm3.rules.mk
@@ -234,36 +234,36 @@ styleclean: $(STYLECHECKFILES:=.styleclean)
 ifeq ($(STLINK_PORT),)
 ifeq ($(BMP_PORT),)
 ifeq ($(OOCD_FILE),)
-%.flash: %.elf
+%.flash: %.srec
 	@printf "  FLASH   $<\n"
-	(echo "halt; program $(realpath $(*).elf) verify reset" | nc -4 localhost 4444 2>/dev/null) || \
+	(echo "halt; program $(realpath $(*).srec) verify reset" | nc -4 localhost 4444 2>/dev/null) || \
 		$(OOCD) -f interface/$(OOCD_INTERFACE).cfg \
 		-f target/$(OOCD_TARGET).cfg \
-		-c "program $(*).elf verify reset exit" \
+		-c "program $(*).srec verify reset exit" \
 		$(NULL)
 else
-%.flash: %.elf
+%.flash: %.srec
 	@printf "  FLASH   $<\n"
-	(echo "halt; program $(realpath $(*).elf) verify reset" | nc -4 localhost 4444 2>/dev/null) || \
+	(echo "halt; program $(realpath $(*).srec) verify reset" | nc -4 localhost 4444 2>/dev/null) || \
 		$(OOCD) -f $(OOCD_FILE) \
-		-c "program $(*).elf verify reset exit" \
+		-c "program $(*).srec verify reset exit" \
 		$(NULL)
 endif
 else
-%.flash: %.elf
-	@printf "  GDB   $(*).elf (flash)\n"
+%.flash: %.srec
+	@printf "  GDB   $(*).srec (flash)\n"
 	$(GDB) --batch \
 		   -ex 'target extended-remote $(BMP_PORT)' \
 		   -x $(SCRIPT_DIR)/black_magic_probe_flash.scr \
-		   $(*).elf
+		   $(*).srec
 endif
 else
-%.flash: %.elf
-	@printf "  GDB   $(*).elf (flash)\n"
+%.flash: %.srec
+	@printf "  GDB   $(*).srec (flash)\n"
 	$(GDB) --batch \
 		   -ex 'target extended-remote $(STLINK_PORT)' \
 		   -x $(SCRIPT_DIR)/stlink_flash.scr \
-		   $(*).elf
+		   $(*).srec
 endif
 
 .PHONY: images clean stylecheck styleclean elf bin hex srec list


### PR DESCRIPTION
I can't explain why flashing openDPS used to overwrite the bootloader, but we can work around the issue by using srecs for flashing rather than elf files.

To check, make the srec files, start openOCD, open a telnet session to it, and run e.g. 

    program dpsboot/dpsboot.srec verify reset
    verify_image dpsboot/dpsboot.srec

    program opendps/opendps_DPS3005.srec verify

    verify_image dpsboot/dpsboot.srec
    verify_image opendps/opendps_DPS3005.srec

All verifications should succeed.