### PR TITLE
Watchdog

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,5 @@ xcuserdata/
 emu/dpsemu
 emu/dpsemu.exe
 esp8266-proxy/private_ssid_config.h
+.*.swp
+.*.swo

--- a/opendps/Makefile
+++ b/opendps/Makefile
@@ -95,6 +95,7 @@ OBJS = \
     event.o \
     past.o \
     tick.o \
+    wdog.o \
     tft.o \
     spi_driver.o \
     ringbuf.o \

--- a/opendps/Makefile
+++ b/opendps/Makefile
@@ -27,6 +27,9 @@ WIFI := 1
 # Print debug information on the serial output
 DEBUG ?= 0
 
+# enable HW watchdog
+WDOG ?= 1
+
 # Font file
 METER_FONT_FILE ?= gfx/Ubuntu-C.ttf
 METER_FONT_SMALL_SIZE ?= 18
@@ -95,7 +98,6 @@ OBJS = \
     event.o \
     past.o \
     tick.o \
-    wdog.o \
     tft.o \
     spi_driver.o \
     ringbuf.o \
@@ -123,6 +125,12 @@ ifeq ($(DEBUG),1)
 	CFLAGS +=-DCONFIG_DEBUG
 	OBJS += dbg_printf.o
 endif
+
+ifeq ($(WDOG),1)
+	CFLAGS +=-DCONFIG_WDOG
+	OBJS += wdog.o
+endif
+
 
 ifeq ($(INVERT_ENABLE),1)
 	CFLAGS +=-DCONFIG_INVERT_ENABLE

--- a/opendps/hw.c
+++ b/opendps/hw.c
@@ -157,7 +157,6 @@ void hw_init(void)
 #ifdef CONFIG_FUNCGEN_ENABLE
     tim3_init();
 #endif
-    wdog_init();
 
 //    AFIO_MAPR |= AFIO_MAPR_PD01_REMAP; /** @todo The original DPS FW does this, things go south if I do it... */
 }

--- a/opendps/hw.c
+++ b/opendps/hw.c
@@ -40,7 +40,6 @@
 #include "hw.h"
 #include "event.h"
 #include "dps-model.h"
-#include "wdog.h"
 
 /** Linker file symbols */
 extern uint32_t *_ram_vect_start;

--- a/opendps/hw.c
+++ b/opendps/hw.c
@@ -40,6 +40,7 @@
 #include "hw.h"
 #include "event.h"
 #include "dps-model.h"
+#include "wdog.h"
 
 /** Linker file symbols */
 extern uint32_t *_ram_vect_start;
@@ -156,6 +157,7 @@ void hw_init(void)
 #ifdef CONFIG_FUNCGEN_ENABLE
     tim3_init();
 #endif
+    wdog_init();
 
 //    AFIO_MAPR |= AFIO_MAPR_PD01_REMAP; /** @todo The original DPS FW does this, things go south if I do it... */
 }

--- a/opendps/opendps.c
+++ b/opendps/opendps.c
@@ -58,6 +58,7 @@
 #include "font-meter_medium.h"
 #include "font-meter_large.h"
 #include "gpio.h"
+#include "wdog.h"
 #include "past.h"
 #include "pastunits.h"
 #include "uui.h"
@@ -978,6 +979,8 @@ static void event_handler(void)
             }
             ui_handle_event(event, data);
         }
+
+        wdog_kick();
     }
 }
 

--- a/opendps/opendps.c
+++ b/opendps/opendps.c
@@ -1038,6 +1038,7 @@ int main(int argc, char const *argv[])
     tft_clear();
     uui_refresh(current_ui, true);
 #endif // CONFIG_SPLASH_SCREEN
+    wdog_init();
     event_handler();
     return 0;
 }

--- a/opendps/opendps.c
+++ b/opendps/opendps.c
@@ -980,7 +980,9 @@ static void event_handler(void)
             ui_handle_event(event, data);
         }
 
+#ifdef CONFIG_WDOG
         wdog_kick();
+#endif // CONFIG_WDOG
     }
 }
 
@@ -1038,7 +1040,9 @@ int main(int argc, char const *argv[])
     tft_clear();
     uui_refresh(current_ui, true);
 #endif // CONFIG_SPLASH_SCREEN
+#ifdef CONFIG_WDOG
     wdog_init();
+#endif // CONFIG_WDOG
     event_handler();
     return 0;
 }

--- a/opendps/wdog.c
+++ b/opendps/wdog.c
@@ -4,15 +4,34 @@
 #include "tick.h"
 #include "wdog.h"
 
+#ifdef WDOG_MEASURE_INTERVAL
+uint32_t max_wdog_interval = 0;
+uint64_t last_tick = 0;
+#endif
+
 void wdog_init(void)
 {
     iwdg_set_period_ms(200);
 
     iwdg_start();
+
+#ifdef WDOG_MEASURE_INTERVAL
+    last_tick = get_ticks();
+#endif
 }
 
 void wdog_kick(void)
 {
-    iwdg_reset();
+#ifdef WDOG_MEASURE_INTERVAL
+    uint64_t tick = get_ticks();
+    uint32_t interval = tick - last_tick;
 
+    if (interval > max_wdog_interval)
+    {
+        max_wdog_interval = interval;
+    }
+    last_tick = tick;
+#endif
+
+    iwdg_reset();
 }

--- a/opendps/wdog.c
+++ b/opendps/wdog.c
@@ -1,0 +1,18 @@
+
+#include <iwdg.h>
+
+#include "tick.h"
+#include "wdog.h"
+
+void wdog_init(void)
+{
+    iwdg_set_period_ms(200);
+
+    iwdg_start();
+}
+
+void wdog_kick(void)
+{
+    iwdg_reset();
+
+}

--- a/opendps/wdog.h
+++ b/opendps/wdog.h
@@ -1,0 +1,7 @@
+#ifndef __WDOG_H__
+#define __WDOG_H__
+
+void wdog_init(void);
+void wdog_kick(void);
+
+#endif // __WDOG_H__


### PR DESCRIPTION
I've implemented a basic watchdog timer, because I'm currently working on a project where I'd like the additional safety. See also issue #145 .

Since pretty much everything happens in the event_handler loop, I figured kicking the watchdog from there should work : so long as we can keep processing events, we're good.


However, with this simple approach we need to set the watchdog quite high. Switching to the function generator screen takes 110ms. I've set it to 200ms for now, since I'm not sure what the longest operations would be. Most other events seem to take only a few ms. Switching from CL to CC screen or similar takes less than 30ms.

If the system would hang, and we ignore an OCP or OVP for 200ms, how problematic is that? Do we need a more sophisticated watchdog, or will this be OK?


If we're going to go with this simple solution, a few more measurements of long-duration events would be welcome. I've included some instrumentation code, under ifdefs. I didn't want to clutter up the makefile, so you should just add the #define at the top of the file. (If you prefer I could put it in the makefile as well, just let me know.)
For getting the value of max_wdog_interval I just run it with gdb attached, and from time to time halt it and print the value. It could of course be modified that it (periodically?) dbg_prints the value.