### PR TITLE
Fix LCD freezing on DPS5020 models.

### DIFF
--- a/opendps/hw.h
+++ b/opendps/hw.h
@@ -37,7 +37,7 @@
 #define TFT_RST_PIN  GPIO12
 #define TFT_A0_PORT  GPIOB
 #define TFT_A0_PIN   GPIO14
-#ifdef DPS5015 
+#if(defined DPS5015) || defined(DPS5020) 
 #define TFT_CSN_PORT GPIOA
 #define TFT_CSN_PIN  GPIO8
 #endif


### PR DESCRIPTION
Hi, 
Please find a change to apply the LCD freeze workaround to the DPS5020 model.