### PR TITLE
opendps/uframe: check for overflow

### DIFF
--- a/dpsboot/dpsboot.c
+++ b/dpsboot/dpsboot.c
@@ -190,15 +190,16 @@ static void handle_frame(uint8_t *payload, uint32_t length)
 {
     command_t cmd = cmd_response;
     upgrade_status_t status;
-    frame_t frame;
-    int32_t payload_len = uframe_extract_payload(&frame, payload, length);
+    int32_t payload_len = uframe_extract_payload_inplace(payload, length);
 
     if (payload_len > 0) {
-        cmd = frame.buffer[0];
+        cmd = payload[0];
         switch(cmd) {
             case cmd_upgrade_start:
             {
                 {
+                    frame_t frame;
+                    uframe_from_extracted_payload(&frame, payload, payload_len);
                     start_frame_unpacking(&frame);
                     unpack8(&frame, &cmd);
                     unpack16(&frame, &chunk_size);

--- a/opendps/uframe.c
+++ b/opendps/uframe.c
@@ -231,6 +231,11 @@ int32_t uframe_extract_payload(frame_t *frame, uint8_t *data, uint32_t length)
         }
     } while(0);
 
+    if (status > sizeof(frame->buffer))
+    {
+        status = -E_LEN;
+    }
+
     if (status >= 0)
     {
         memcpy(frame->buffer, data, status);

--- a/opendps/uframe.c
+++ b/opendps/uframe.c
@@ -179,23 +179,11 @@ uint32_t unpack32(frame_t *frame, uint32_t *data)
     return bytes_read;
 }
 
-/**
-  * @brief Extract payload from frame following deframing, unescaping and
-  *       crc checking.
-  * @note The frame is processed 'in place', when exiting the payload will be
-  *       the first byte of 'frame'. If the frame contains two valid frames,
-  *       -E_CRC will be returned.
-  * @param frame the frame to process, payload on exit
-  * @param length length of frame
-  * @retval length of payload or -E_* in case of errors (see uframe.h)
-  */
-int32_t uframe_extract_payload(frame_t *frame, uint8_t *data, uint32_t length)
+int32_t uframe_extract_payload_inplace(uint8_t *data, uint32_t length)
 {
     int32_t status = -1;
     bool seen_dle = false;
     uint16_t frame_crc, calc_crc = 0;
-
-    frame->length = 0;
 
     do {
         if (length < 5) { // _SOF CRC16 _EOF is no usable frame
@@ -231,16 +219,28 @@ int32_t uframe_extract_payload(frame_t *frame, uint8_t *data, uint32_t length)
         }
     } while(0);
 
-    if (status > sizeof(frame->buffer))
-    {
-        status = -E_LEN;
-    }
-
-    if (status >= 0)
-    {
-        memcpy(frame->buffer, data, status);
-        frame->length = status;
-    }
-
     return status;
+}
+
+
+int32_t uframe_extract_payload(frame_t *frame, uint8_t *data, uint32_t length)
+{
+    frame->length = 0;
+    int32_t result = uframe_extract_payload_inplace(data, length);
+    if (result > MAX_FRAME_LENGTH) {
+        result = -E_LEN;
+    }
+
+    if (result >= 0)
+    {
+        uframe_from_extracted_payload(frame, data, result);
+    }
+
+    return result;
+}
+
+void uframe_from_extracted_payload(frame_t *frame, const uint8_t *data, uint32_t length)
+{
+    memcpy(frame->buffer, data, length);
+    frame->length = length;
 }

--- a/opendps/uframe.h
+++ b/opendps/uframe.h
@@ -33,7 +33,7 @@
 #define _EOF 0x7f
 
 /** Errors returned by uframe_unescape(...) */
-#define E_LEN 1 // Received frame is too short to be a uframe
+#define E_LEN 1 // Received frame is too short or too long to be a uframe
 #define E_FRM 2 // Received data has no framing
 #define E_CRC 3 // CRC mismatch
 

--- a/opendps/uframe.h
+++ b/opendps/uframe.h
@@ -71,14 +71,35 @@ uint32_t unpack32(frame_t *frame, uint32_t *data);
 /**
   * @brief Extract payload from frame following deframing, unescaping and
   *       crc checking.
-  * @note The frame is processed 'in place', when exiting the payload will be
-  *       the first byte of 'frame'. If the frame contains two valid frames,
-  *       -E_CRC will be returned.
+  * @note Like @ref uframe_extract_payload_inplace but `memcpy()`s the data
+  *       into @p frame.
   * @param frame  the returned processed frame
   * @param data   the raw data to be processed
   * @param length length of frame
   * @retval length of payload or -E_* in case of errors (see uframe.h)
   */
 int32_t uframe_extract_payload(frame_t *frame, uint8_t *data, uint32_t length);
+
+/**
+  * @brief Extract payload from frame following deframing, unescaping and
+  *       crc checking.
+  * @note The frame is processed 'in place', when exiting the payload will be
+  *       the first byte of 'frame'. If the frame contains two valid frames,
+  *       -E_CRC will be returned.
+  * @param data   the raw data to be processed
+  * @param length length of frame
+  * @retval length of payload or -E_* in case of errors (see uframe.h)
+  */
+int32_t uframe_extract_payload_inplace(uint8_t *data, uint32_t length);
+
+/**
+  * @brief Initializes an `frame_t` with the already extracted data
+  * @param frame  The frame to initialize
+  * @param data   The already extracted data (see @ref uframe_extract_payload_inplace)
+  * @param length The length of @p data
+  *
+  * @note You will probably want to use @ref uframe_extract_payload instead
+  */
+void uframe_from_extracted_payload(frame_t *frame, const uint8_t *data, uint32_t length);
 
 #endif // __UFRAME_H__


### PR DESCRIPTION
Instead of calling `memcpy` with a too large payload, bail out and report the error when the received uframe is too large.