### PR TITLE
Fix SPI initialization for libopencm3 update

### DIFF
--- a/opendps/spi_driver.c
+++ b/opendps/spi_driver.c
@@ -53,7 +53,8 @@ void spi_init(void)
 
     rcc_periph_clock_enable(RCC_SPI2);
     rcc_periph_clock_enable(RCC_DMA1);
-    rcc_periph_reset_pulse(RST_SPI2);
+    rcc_periph_reset_hold(RST_SPI2);
+    rcc_periph_reset_release(RST_SPI2);
     SPI2_I2SCFGR = 0;
     spi_init_master(SPI2, SPI_CR1_BAUDRATE_FPCLK_DIV_2, SPI_CR1_CPOL_CLK_TO_1_WHEN_IDLE, SPI_CR1_CPHA_CLK_TRANSITION_2, SPI_CR1_DFF_8BIT, SPI_CR1_MSBFIRST);
 


### PR DESCRIPTION
## Summary
Fixes black screen issue caused by commit c52ebac which updated libopencm3 and changed SPI reset method.

## Root Cause
Commit c52ebac replaced `spi_reset(SPI2)` with `rcc_periph_reset_pulse(RST_SPI2)` during libopencm3 update. However, `rcc_periph_reset_pulse()` in newer libopencm3 doesn't properly complete the reset sequence, leaving SPI peripheral in undefined state and causing ILI9163C display controller initialization to fail.

## Fix
Replace `rcc_periph_reset_pulse(RST_SPI2)` with explicit two-step reset:
- `rcc_periph_reset_hold(RST_SPI2)` - Assert reset
- `rcc_periph_reset_release(RST_SPI2)` - Release reset

This ensures proper reset timing and restores display functionality.

## Testing
- Tested on DPS5015 hardware with Black Magic Probe
- Display now functions correctly after firmware flash
- No other functionality affected

AI slop, but I tested it