### PR TITLE
Fix typo in README: 'Plese note' -> 'Please note'

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,7 +174,7 @@ The project consists of four parts:
 
 ### What about other DPS:es?
 
-OpenDPS has been verified to work with other models in the DPSx0xx series, such as the DPS3003, DPS3005, DPS5015 and DPS5020. The maxium settable output current can be defined when building opendps, see the makefile. Plese note that the hardware design might change at any time without any notice (I am not affiliated with its designer). This will render OpenDPS unusable until fixed.
+OpenDPS has been verified to work with other models in the DPSx0xx series, such as the DPS3003, DPS3005, DPS5015 and DPS5020. The maxium settable output current can be defined when building opendps, see the makefile. Please note that the hardware design might change at any time without any notice (I am not affiliated with its designer). This will render OpenDPS unusable until fixed.
 
 ---
 Licensed under the MIT license. Have fun!


### PR DESCRIPTION
Corrected the spelling of 'Plese' to 'Please' in the caution about hardware design changes.