### PR TITLE
dpsctl: allow installing via `pipx install .`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ emu/dpsemu.exe
 esp8266-proxy/private_ssid_config.h
 .*.swp
 .*.swo
+/dpsctl.egg-info

--- a/dpsctl.py
+++ b/dpsctl.py
@@ -1,0 +1,4 @@
+#!/usr/bin/env python3
+from dpsctl.dpsctl import main
+
+main()

--- a/dpsctl/dpsctl.py
+++ b/dpsctl/dpsctl.py
@@ -50,13 +50,13 @@ calibration_debug_plotting = False  # Change this to True to enable plotting of 
 if calibration_debug_plotting:
     import matplotlib.pyplot as plt
 
-import protocol
-import uframe
-from protocol import (create_cmd, create_enable_output, create_lock, create_set_calibration,
-                      create_set_function, create_set_parameter, create_temperature, create_set_brightness,
-                      create_set_baud, create_upgrade_data, create_upgrade_start, create_change_screen,
-                      unpack_cal_report, unpack_query_response, unpack_version_response,
-                      VALID_BAUD_RATES)
+import dpsctl.protocol as protocol
+import dpsctl.uframe as uframe
+from dpsctl.protocol import (create_cmd, create_enable_output, create_lock, create_set_calibration,
+                             create_set_function, create_set_parameter, create_temperature, create_set_brightness,
+                             create_set_baud, create_upgrade_data, create_upgrade_start, create_change_screen,
+                             unpack_cal_report, unpack_query_response, unpack_version_response,
+                             VALID_BAUD_RATES)
 
 try:
     import serial

--- a/dpsctl/dpsctl.py
+++ b/dpsctl/dpsctl.py
@@ -1205,7 +1205,7 @@ def main():
     testing = '--testing' in sys.argv
     parser = argparse.ArgumentParser(description='Instrument an OpenDPS device')
 
-    parser.add_argument('-d', '--device', help="OpenDPS device to connect to. Can be a /dev/tty device, IP address for UDP protocol or tcp:IP for TCP protocol. If omitted, dpsctl.py will try the environment variable DPSIF", default='')
+    parser.add_argument('-d', '--device', help="OpenDPS device to connect to. Can be a /dev/tty device, IP address for UDP protocol or tcp:IP for TCP protocol. If omitted, dpsctl.py will try the environment variable DPSIF", default=os.getenv('DPSCTL_DEVICE'))
     parser.add_argument('-b', '--baudrate', type=int, dest="baudrate", help="Set baudrate used for serial communications", default=9600)
     parser.add_argument('-B', '--brightness', type=int, help="Set display brightness (0..100)")
     parser.add_argument('--set-baud', type=int, dest="set_baud", default=None,

--- a/dpsctl/protocol.py
+++ b/dpsctl/protocol.py
@@ -24,7 +24,7 @@ THE SOFTWARE.
 
 import struct
 
-from uframe import uFrame
+from dpsctl.uframe import uFrame
 
 # command_t
 CMD_PING = 1

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,22 @@
+from setuptools import setup
+
+setup(name='dpsctl',
+      version='0.1',
+      description='Python utility to interact with OpenDPS firmware for DPS5005 power supplies',
+      url='https://github.com/kanflo/opendps',
+      author='Johan Kanflo',
+      author_email='watski@bitfuse.net',
+      license='MIT',
+      packages=['dpsctl', 'uhej'],
+      package_dir={
+            'uhej': 'dpsctl/uhej',
+      },
+      install_requires=[
+            'pyserial',
+      ],
+      entry_points = {
+            'console_scripts': [
+                  'dpsctl = dpsctl.dpsctl:main',
+            ],
+      },
+      zip_safe=False)


### PR DESCRIPTION
#### [dpsctl: allow installing via pipx](https://github.com/kanflo/opendps/commit/211e05ea40e0a6c2a13e50523adba4cb6a2041b1)
This adds a `setup.py` to allow installing dpsctl via `pipx install .`. For compatibility with that, all `imports` had to be converted to full absolute paths (adding a `dpsctl.` prefix to them), which breaks running `dpsctl/dpsctl.py` directly. To indicate that this no longer is possible, the executable permission has been revoked.

In addition, a new `dpsctl.py` has been added to the root level as a two line wrapper that executes `main` from `dpsctl.dpsctl`, so that running `./dpsctl.py` again is possible without installation (but now in the root of the git repo, rather than in the `dpsctl` sub folder).

#### [.gitignore: add dpsctl.egg-info](https://github.com/kanflo/opendps/commit/fa696a5af917bfe1972803401b280d60bcaade4a)

The folder `dpsctl.egg-info` is generated when running `pipx install .` and not needed to be
tracked by git. Hence, adding it to `.gitignore`.

#### [dpsctl: allow setting device via env](https://github.com/kanflo/opendps/commit/e07141fe69b4f5d8b73de2a9be6a8404831eba16)

Adding `export DPSCTL_DEVICE=/dev/ttyXYZ` to your `~/.profile` / `~/.bashrc` / `~/.zshrc` / ... allos dropping the `-d /dev/ttyXZY` parameter. It is only passed in as default, so overwriting via command line remains possible. Not having that environment variable exported results in no change of behavior.
