### PR TITLE
dpsboot: watchdog feeding and a clone-safe clock option

### DIFF
--- a/dpsboot/Makefile
+++ b/dpsboot/Makefile
@@ -8,6 +8,12 @@ CFLAGS = -I. -I../opendps -DGIT_VERSION=\"$(GIT_VERSION)\" -DCONFIG_PAST_NO_GC -
 # LTO saves ~600 bytes; requires gcc > 7 (all modern ARM toolchains qualify)
 CFLAGS += -flto
 
+# Build with CLOCK_8MHZ=1 to skip the 48MHz PLL bring-up and run off HSI.
+# For units with clone MCUs that hang or fault during the 48MHz clock setup.
+ifeq ($(CLOCK_8MHZ),1)
+	CFLAGS += -DCONFIG_BOOT_CLOCK_HSI_8MHZ
+endif
+
 EXT_DIR = ../opendps/
 
 DPS_OBJ_DIR = dpsobj

--- a/dpsboot/dpsboot.c
+++ b/dpsboot/dpsboot.c
@@ -34,6 +34,7 @@
 #include <usart.h>
 #include <timer.h>
 #include <flash.h>
+#include <iwdg.h>
 #include "tick.h"
 #include "hw.h"
 #include "ringbuf.h"
@@ -114,6 +115,11 @@ static void handle_upgrade(void)
 
     while(1) {
         uint16_t b;
+        /** The app may have started the IWDG which keeps running across the
+          * soft reset into this bootloader and cannot be disabled. Keep it
+          * fed or it will reset us mid upgrade (kicking an unstarted IWDG
+          * is harmless). */
+        iwdg_reset();
         if (ringbuf_get(&rx_buf, &b)) {
             if (b == _SOF) {
                 receiving_frame = true;
@@ -191,6 +197,8 @@ static void handle_frame(uint8_t *payload, uint32_t length)
     command_t cmd = cmd_response;
     upgrade_status_t status;
     int32_t payload_len = uframe_extract_payload_inplace(payload, length);
+
+    iwdg_reset(); /** Cover the flash erase/write below in case the app started the IWDG */
 
     if (payload_len > 0) {
         cmd = payload[0];
@@ -304,8 +312,16 @@ int main(void)
     ringbuf_init(&rx_buf, (uint8_t*) buffer, sizeof(buffer));
     hw_init(&rx_buf);
 
+    /** If the app started the IWDG (200ms period) it survives the soft reset
+      * into this bootloader and cannot be disabled. Keep it fed from the very
+      * start or we will be reset over and over during an upgrade, tearing
+      * flash writes and corrupting past. Kicking an unstarted IWDG is a nop. */
+    iwdg_reset();
+
     do {
-        if (hw_check_forced_upgrade()) {
+        bool forced = hw_check_forced_upgrade();
+        iwdg_reset(); /** hw_check_forced_upgrade blocks for 100ms */
+        if (forced) {
             /** This gives us an opportunity to enter upgrade as early as
               * possible in case we flashed something really really fishy. */
             enter_upgrade = true;

--- a/dpsboot/hw.c
+++ b/dpsboot/hw.c
@@ -94,8 +94,18 @@ void usart1_isr(void)
   */
 static void clock_init(void)
 {
+#ifdef CONFIG_BOOT_CLOCK_HSI_8MHZ
+    /** Run straight off the 8MHz HSI: no PLL, no flash wait state change.
+      * For units with clone MCUs that misbehave during the 48MHz clock
+      * bring-up. The bootloader has no need for speed and the peripheral
+      * drivers pick the frequency up from the rcc_*_frequency globals. */
+    rcc_ahb_frequency = 8000000;
+    rcc_apb1_frequency = 8000000;
+    rcc_apb2_frequency = 8000000;
+#else
     rcc_clock_setup_in_hsi_out_48mhz();
     // rcc_clock_setup_pll(&rcc_hsi_configs[RCC_CLOCK_HSI_48MHZ]);
+#endif
     rcc_periph_clock_enable(RCC_GPIOA);
     rcc_periph_clock_enable(RCC_GPIOB);
     rcc_periph_clock_enable(RCC_GPIOC);


### PR DESCRIPTION
Two hardening changes for the bootloader, found while un-bricking and upgrading two DPS5005 units.

## Feed the IWDG while upgrading

On devices where the IWDG is running when the bootloader executes — the `IWDG_SW` option byte selects a hardware watchdog that runs from reset, and clone MCUs have been seen with diverging IWDG behaviour — the bootloader gets reset every watchdog period (200 ms with the app's setting) while waiting in upgrade mode or programming flash. Interrupted flash writes tear the `past` area, which can leave the device hard-faulting at boot (we recovered one unit from exactly this state: its past contained dozens of torn `past_upgrade_started` writes and a corrupted git-hash unit that crashed the bootloader's hash comparison at every boot).

The fix kicks the IWDG at boot, in the upgrade receive loop and around flash writes. Kicking an IWDG that is not running is a no-op, so this costs nothing on devices with a software-controlled watchdog.

## CLOCK_8MHZ build option

One of the two DPS5005 units carries an MCU that reports a genuine STM32F100 IDCODE (`0x420`, 64 KB) but hard-faults during the bootloader's 48 MHz PLL bring-up with current libopencm3 — single-stepping under SWD showed the flash interface returning garbage right after the wait-state configuration. Curiously the same unit runs the *app's* identical 48 MHz setup fine, so this appears to be a clone die that is sensitive to the exact boot-time sequence.

Building with `make CLOCK_8MHZ=1` makes the bootloader run straight off the 8 MHz HSI: no PLL, no flash wait-state change. The bootloader has no need for speed — UART baud rates derive from the `rcc_*_frequency` globals and flash programming time is dominated by the flash hardware. The default build is unchanged.

## Testing

- Default build verified on a genuine-silicon DPS5005: boots, upgrades over serial at 9600 and 115200.
- `CLOCK_8MHZ=1` build verified on the clone-MCU DPS5005 that previously hard-faulted before reaching the upgrade loop: it now boots, starts the app, and completes serial upgrades.
- Both variants compile warning-free and fit the 5 KB bootloader region (4.1–4.6 KB).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
